### PR TITLE
Lock ng2-bootstrap to 1.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jquery": "^2.2.3",
     "lodash": "^4.11.1",
     "moment": "^2.13.0",
-    "ng2-bootstrap": "^1.1.8",
+    "ng2-bootstrap": "1.1.13",
     "reflect-metadata": "~0.1.8",
     "rxjs": "5.0.0-beta.12",
     "systemjs": "0.19.31",


### PR DESCRIPTION
Lock ng2-bootstrap to version 1.1.13 to avoid broken UI