### PR TITLE
added security to the snmpcollector API

### DIFF
--- a/pkg/webcontext.go
+++ b/pkg/webcontext.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/macaron.v1"
+)
+
+type Context struct {
+	*macaron.Context
+	SignedInUser string
+	Session      SessionStore
+	IsSignedIn   bool
+}
+
+func accessForbidden(ctx *Context) {
+	ctx.JSON(403, fmt.Errorf("access forbidden %+v", ctx))
+	//c.SetCookie("redirect_to", url.QueryEscape(c.Req.RequestURI), 0, "/")
+	//c.Redirect("/login")
+}
+
+var reqSignedIn = func(ctx *Context) {
+	if !ctx.IsSignedIn {
+		accessForbidden(ctx)
+		log.Infof("CONTEXT %+v", ctx)
+		return
+	}
+}
+
+func initContextWithUserSessionCookie(ctx *Context) bool {
+	// initialize session
+	if err := ctx.Session.Start(ctx); err != nil {
+		log.Error("Failed to start session", "error", err)
+		return false
+	}
+	userId := ctx.Session.Get(SESS_KEY_USERID)
+
+	if userId != nil {
+		ctx.SignedInUser = ctx.Session.Get(SESS_KEY_USERID).(string)
+		ctx.IsSignedIn = true
+		return true
+	}
+
+	return false
+
+}
+
+func GetContextHandler() macaron.Handler {
+	return func(c *macaron.Context) {
+		ctx := &Context{
+			Context:      c,
+			SignedInUser: "",
+			Session:      GetSession(),
+			IsSignedIn:   false,
+		}
+
+		// the order in which these are tested are important
+		// look for api key in Authorization header first
+		// then init session and look for userId in session
+		// then look for api key in session (special case for render calls via api)
+		// then test if anonymous access is enabled
+		if initContextWithUserSessionCookie(ctx) {
+
+		}
+
+		ctx.Data["ctx"] = ctx
+		c.Map(ctx)
+	}
+}

--- a/pkg/websession.go
+++ b/pkg/websession.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"github.com/go-macaron/session"
+	"gopkg.in/macaron.v1"
+	"time"
+)
+
+const (
+	SESS_KEY_USERID = "uid"
+)
+
+var sessionManager *session.Manager
+var sessionOptions *session.Options
+var startSessionGC func()
+var getSessionCount func() int
+
+func init() {
+	fmt.Println("init session")
+	startSessionGC = func() {
+		sessionManager.GC()
+		time.AfterFunc(time.Duration(sessionOptions.Gclifetime)*time.Second, startSessionGC)
+	}
+	getSessionCount = func() int {
+		return sessionManager.Count()
+	}
+}
+
+func prepareOptions(opt *session.Options) *session.Options {
+	if len(opt.Provider) == 0 {
+		opt.Provider = "memory"
+	}
+	if len(opt.ProviderConfig) == 0 {
+		opt.ProviderConfig = "data/sessions"
+	}
+	if len(opt.CookieName) == 0 {
+		opt.CookieName = "snmpcollector-session"
+	}
+	if len(opt.CookiePath) == 0 {
+		opt.CookiePath = "/"
+	}
+	if opt.Gclifetime == 0 {
+		opt.Gclifetime = 3600
+	}
+	if opt.Maxlifetime == 0 {
+		opt.Maxlifetime = opt.Gclifetime
+	}
+	if opt.IDLength == 0 {
+		opt.IDLength = 16
+	}
+
+	return opt
+}
+
+func Sessioner(options session.Options) macaron.Handler {
+	var err error
+	sessionOptions = prepareOptions(&options)
+	sessionManager, err = session.NewManager(options.Provider, options)
+	if err != nil {
+		panic(err)
+	}
+
+	go startSessionGC()
+
+	return func(ctx *Context) {
+		ctx.Next()
+
+		if err = ctx.Session.Release(); err != nil {
+			panic("session(release): " + err.Error())
+		}
+	}
+}
+
+func GetSession() SessionStore {
+	return &SessionWrapper{manager: sessionManager}
+}
+
+type SessionStore interface {
+	// Set sets value to given key in session.
+	Set(interface{}, interface{}) error
+	// Get gets value by given key in session.
+	Get(interface{}) interface{}
+	// ID returns current session ID.
+	ID() string
+	// Release releases session resource and save data to provider.
+	Release() error
+	// Destory deletes a session.
+	Destory(*Context) error
+	// init
+	Start(*Context) error
+}
+
+type SessionWrapper struct {
+	session session.RawStore
+	manager *session.Manager
+}
+
+func (s *SessionWrapper) Start(c *Context) error {
+	var err error
+	s.session, err = s.manager.Start(c.Context)
+	return err
+}
+
+func (s *SessionWrapper) Set(k interface{}, v interface{}) error {
+	if s.session != nil {
+		return s.session.Set(k, v)
+	}
+	return nil
+}
+
+func (s *SessionWrapper) Get(k interface{}) interface{} {
+	if s.session != nil {
+		return s.session.Get(k)
+	}
+	return nil
+}
+
+func (s *SessionWrapper) ID() string {
+	if s.session != nil {
+		return s.session.ID()
+	}
+	return ""
+}
+
+func (s *SessionWrapper) Release() error {
+	if s.session != nil {
+		return s.session.Release()
+	}
+	return nil
+}
+
+func (s *SessionWrapper) Destory(c *Context) error {
+	if s.session != nil {
+		if err := s.manager.Destory(c.Context); err != nil {
+			return err
+		}
+		s.session = nil
+	}
+	return nil
+}

--- a/public/app/app.routes.ts
+++ b/public/app/app.routes.ts
@@ -4,7 +4,7 @@ import { Login } from '../login/login';
 import { AuthGuard } from '../common/auth.guard';
 
 export const routes: Routes = [
-  { path: '',   component: Login },
+  { path: '',   component: Home, canActivate: [AuthGuard]  },
   { path: 'login',  component: Login },
   { path: 'home',   component: Home, canActivate: [AuthGuard] },
 ];

--- a/public/home/home.ts
+++ b/public/home/home.ts
@@ -4,6 +4,7 @@ import { Http, Headers } from '@angular/http';
 import { AuthHttp,JwtHelper } from 'angular2-jwt';
 import { Router } from '@angular/router';
 import * as _ from 'lodash';
+import { contentHeaders } from '../common/headers';
 
 
 
@@ -34,9 +35,18 @@ export class Home {
   }
 
   logout() {
-    localStorage.removeItem('username');
-    localStorage.removeItem('id_token');
-    this.router.navigate(['']);
+    this.http.post('/logout', { headers: contentHeaders })
+      .subscribe(
+        response => {
+          localStorage.removeItem('username');
+          localStorage.removeItem('id_token');
+          this.router.navigate(['/login']);
+        },
+        error => {
+          alert(error.text());
+          console.log(error.text());
+        }
+      );
   }
 
   InfluxServers() {

--- a/public/login/login.ts
+++ b/public/login/login.ts
@@ -17,7 +17,7 @@ export class Login {
   login(event, username, password) {
     event.preventDefault();
     let body = JSON.stringify({ username, password });
-    this.http.post('/session/create', body, { headers: contentHeaders })
+    this.http.post('/login', body, { headers: contentHeaders })
       .subscribe(
         response => {
           console.log('id_token: '+response.json())


### PR DESCRIPTION
Now only logged in people can access to the snmpcollector API.

This is a requirement to add online runtime control like , agent restart, and device runtime activation/deactivation , etc.