### PR TITLE
Add report metric field option on add and edit measurements forms

### DIFF
--- a/public/influxmeas/influxmeascfg.service.ts
+++ b/public/influxmeas/influxmeascfg.service.ts
@@ -14,11 +14,7 @@ export class InfluxMeasService {
             if ( key == 'Fields' ) {
               if (value == null || value == "")  return null;
               else {
-                let array: any =  [];
-                _.forEach(String(value).split(','),function(val,key){
-                  array.push({'ID': val, 'Report': true})
-                });
-                return array; //String(value).split(',');
+                return value; //String(value).split(',');
               }
             }
             if ( key == 'IndexAsValue' ) return ( value === "true" || value === true);
@@ -33,11 +29,7 @@ export class InfluxMeasService {
           if ( key == 'Fields' ) {
             if (value == null || value == "")  return null;
             else {
-              let array: any = [];
-              _.forEach(String(value).split(','),function(val,key){
-                array.push({'ID': val, 'Report': true})
-              });
-              return array; //String(value).split(',');
+                return value;
             }
           }
           if ( key == 'IndexAsValue' ) return ( value === "true" || value === true);

--- a/public/influxmeas/influxmeaseditor.html
+++ b/public/influxmeas/influxmeaseditor.html
@@ -117,17 +117,34 @@
 
 	</div>
 
-		<div class="form-group">
-  	<label class="control-label col-sm-2" for="Fields">Fields</label>
-		<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
-		tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
-	 <div class="col-sm-9">
-    	<div>
-		  	<ss-multiselect-dropdown [options]="selectmetrics" [texts]="myTexts" [settings]="mySettings" [ngModel]="metricArray" [ngModelOptions]="{standalone: true}" (ngModelChange)="onChange($event)"></ss-multiselect-dropdown>
-		    <control-messages [control]="influxmeasForm.controls.Fields"></control-messages>
-		  </div>
-    </div>
+	<div class="form-group">
+	<label class="control-label col-sm-2" for="Fields">Fields</label>
+	<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
+	tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
+	<div class="col-sm-9">
+		<div>
+			<ss-multiselect-dropdown [options]="selectmetrics" [texts]="myTexts" [settings]="mySettings" [(ngModel)]="selectedMetrics" [ngModelOptions]="{standalone: true}" (ngModelChange)="onChangeMetricArray($event)"></ss-multiselect-dropdown>
+			<control-messages [control]="influxmeasForm.controls.Fields"></control-messages>
+		</div>
 	</div>
+	</div>
+
+	<div class="form-group" *ngIf = "metricArray.length > 0">
+	<label class="control-label col-sm-2" for="Report">Report Fields</label>
+	<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
+	tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
+	<div class="col-sm-9">
+	<div class="input-group list-group">
+		<div *ngFor="let metric of metricArray; let i = index">
+			<span class="input-group-addon ">
+				<input type="checkbox" style="width: auto" (click)="onCheckMetric(i)" [checked]="metricArray[i].Report" >
+			</span>
+			<div class="input-group-addon" style="background: none"><span [ngClass]="metric.Report ? ['text-success'] : ['text-danger']">{{metric.ID}}</span></div>
+		</div>
+		</div><!-- /input-group -->
+	</div>
+	</div>
+
 
 	<div class="form-group">
 	 <label class="control-label col-sm-2" for="Description">Description</label>
@@ -227,17 +244,32 @@
 	</div>
 
 
-		<div class="form-group">
-  	<label class="control-label col-sm-2" for="Fields">Fields</label>
-		<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
-		tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
-	 <div class="col-sm-9">
-			<div>
-				<ss-multiselect-dropdown required [options]="selectmetrics" [texts]="myTexts" [settings]="mySettings" [ngModel]="metricArray" [ngModelOptions]="{standalone: true}" (ngModelChange)="onChange($event)" ></ss-multiselect-dropdown>
-				<control-messages [control]="influxmeasForm.controls.Fields"></control-messages>
-			</div>
+	<div class="form-group">
+	<label class="control-label col-sm-2" for="Fields">Fields</label>
+	<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
+	tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
+ <div class="col-sm-9">
+		<div>
+			<ss-multiselect-dropdown [options]="selectmetrics" [texts]="myTexts" [settings]="mySettings" [(ngModel)]="selectedMetrics" [ngModelOptions]="{standalone: true}" (ngModelChange)="onChangeMetricArray($event)"></ss-multiselect-dropdown>
+			<control-messages [control]="influxmeasForm.controls.Fields"></control-messages>
 		</div>
 	</div>
+</div>
+<div class="form-group" *ngIf = "metricArray.length > 0">
+<label class="control-label col-sm-2" for="Report">Report Fields</label>
+<i tooltipPlacement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true"
+tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
+<div class="col-sm-9">
+	<div class="input-group list-group">
+		<div *ngFor="let metric of metricArray; let i = index">
+      <span class="input-group-addon ">
+        <input type="checkbox" style="width: auto" (click)="onCheckMetric(i)" [checked]="metricArray[i].Report" >
+      </span>
+ 			<div class="input-group-addon" style="background: none"><span [ngClass]="metric.Report ? ['text-success'] : ['text-danger']">{{metric.ID}}</span></div>
+		</div>
+    </div><!-- /input-group -->
+</div>
+</div>
 
 	<div class="form-group">
 	 <label class="control-label col-sm-2" for="Description">Description</label>


### PR DESCRIPTION
This allows the user select if the metric on a defined measurement is sent or not.

The agent will collect the value but it won't be sent on InfluxDB server. It is really useful on new metrics defined as eval type.

![image](https://cloud.githubusercontent.com/assets/13196237/21295640/b9054f68-c559-11e6-992c-5df8458d9eae.png)
