### PR TITLE
Fix occasional filter exception when init multiselect template

### DIFF
--- a/public/measgroup/measgroupcfg.component.ts
+++ b/public/measgroup/measgroupcfg.component.ts
@@ -24,7 +24,7 @@ export class MeasGroupCfgComponent {
   measgroupForm: any;
 	testmeasgroups: any;
 	influxmeas: Array<any>;
-  selectmeas: IMultiSelectOption[];
+  selectmeas: IMultiSelectOption[] = [];
 
 	//Initialization data, rows, colunms for Table
 	private data:Array<any> = [];
@@ -53,7 +53,7 @@ export class MeasGroupCfgComponent {
 		this.reloadData();
 		this.measgroupForm = builder.group({
 			id: ['',Validators.required],
-			Measurements: ['', Validators.compose([Validators.required,Validators.minLength(1)])],
+			Measurements: ['', Validators.required],
 			Description: ['']
 		});
 	}

--- a/public/snmpdevice/snmpdevicecfg.component.ts
+++ b/public/snmpdevice/snmpdevicecfg.component.ts
@@ -35,8 +35,8 @@ export class SnmpDeviceCfgComponent {
     measfilters: Array<any>;
     measgroups: Array<any>;
   	filteroptions: any;
-    selectgroups: IMultiSelectOption[];
-  	selectfilters: IMultiSelectOption[];
+    selectgroups: IMultiSelectOption[] = [];
+  	selectfilters: IMultiSelectOption[] = [];
     alertHandler : any = [];
 
     //Initialization data, rows, colunms for Table


### PR DESCRIPTION
The component was throwing exception when initiating the multiselect if selectable options weren't loaded before its init.