### PR TITLE
UI Fix test connection modal values on snmping using form values

### DIFF
--- a/src/common/test-connection-modal.ts
+++ b/src/common/test-connection-modal.ts
@@ -167,7 +167,7 @@ import { Subscription } from "rxjs";
 
 export class TestConnectionModal implements OnInit  {
   @ViewChild('childModal') public childModal: ModalDirective;
-  @Input() formValues : any;
+  //@Input() formValues : any;
   @Input() titleName : any;
   @Input() systemInfo: any;
   @Output() public validationClicked:EventEmitter<any> = new EventEmitter();
@@ -192,7 +192,7 @@ export class TestConnectionModal implements OnInit  {
 
   //History OIDs
   histArray : Array<string> = [];
-
+  formValues: any;
   //Sysinfo
    alertHandler : any = {};
    isRequesting : boolean ;
@@ -234,17 +234,18 @@ export class TestConnectionModal implements OnInit  {
         this.maximized = !this.maximized;
     }
 
-  show() {
+  show(_formValues) {
       this.getMetricsforModal();
       this.getMeasforModal();
       this.getFiltersforModal();
     //reset var values
+    this.formValues = _formValues;
     this.alertHandler = {};
     this.queryResult = null;
     this.maximized = false;
     this.isConnected = false;
     this.isRequesting = true;
-    this.pingDevice();
+    this.pingDevice(this.formValues);
     this.childModal.show();
   }
 
@@ -309,8 +310,8 @@ export class TestConnectionModal implements OnInit  {
 
 
   //WAIT
-   pingDevice(){
-    this.myObservable = this.snmpDeviceService.pingDevice(this.formValues)
+   pingDevice(formValues){
+    this.myObservable = this.snmpDeviceService.pingDevice(formValues)
     .subscribe(data => {
       this.alertHandler = {msg: 'Test succesfull '+data['SysDescr'], type: 'success', closable: true};
       this.isConnected = true;

--- a/src/snmpdevice/snmpdevicecfg.component.ts
+++ b/src/snmpdevice/snmpdevicecfg.component.ts
@@ -314,7 +314,7 @@ export class SnmpDeviceCfgComponent {
 
   showTestConnectionModal() {
     if (this.snmpdevForm.valid) {
-      this.viewTestConnectionModal.show();
+      this.viewTestConnectionModal.show(this.snmpdevForm.value);
     }
   }
 

--- a/src/snmpdevice/snmpdeviceeditor.html
+++ b/src/snmpdevice/snmpdeviceeditor.html
@@ -305,7 +305,7 @@
         </div>
       </div>
 
-      <test-connection-modal #viewTestConnectionModal titleName='Test connection:' [formValues]="snmpdevForm.value">
+      <test-connection-modal #viewTestConnectionModal titleName='Test connection:'>
       </test-connection-modal>
       <div class="col-sm-2">
         <button type="button" [disabled]="!snmpdevForm.valid" (click)="showTestConnectionModal()">Test Connection</button>
@@ -596,7 +596,7 @@
       <div class="col-sm-2">
         <button type="button" [disabled]="!snmpdevForm.valid" (click)="showTestConnectionModal()">Test Connection</button>
       </div>
-      <test-connection-modal #viewTestConnectionModal titleName='Test connection for:' [formValues]="snmpdevForm.value">
+      <test-connection-modal #viewTestConnectionModal titleName='Test connection for:'>
       </test-connection-modal>
       <div class="col-sm-offset-2 col-sm-3">
         <button type="submit" [disabled]="!snmpdevForm.valid">Submit</button>


### PR DESCRIPTION
Seems it was an error that on sending the ping of testconnection it was using the default value of community (public). Now the show function is passing the updated form from the main component
