### PR TITLE
UI Add ui-blocker component, fix routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,8 +3,8 @@ import { Home } from '../home/home';
 import { Login } from '../login/login';
 
 
-export const routes: Routes = [
-  { path: '',   component: Login },
-  { path: 'login',  component: Login },
-  { path: 'home',   component: Home },
-];
+export const AppRoutes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: Home },
+  { path: 'login', component: Login },
+  ];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
+import { AppRoutes } from './app.routes';
 
 @Component({
   selector: 'snmpcol-app',

--- a/src/common/blockui/blockui-component.ts
+++ b/src/common/blockui/blockui-component.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {SpinnerComponent} from '../spinner'
+@Component({
+    selector: 'blockui',
+    styleUrls: ['./blockui.css'],
+    template:
+    `<div class="in modal-backdrop block-overlay"></div>
+     <div class="block-message-container" aria-live="assertive" aria-atomic="true">
+        <div class="block-message" >    <my-spinner style="margin-right: 20px" [isRunning]=true></my-spinner>
+            {{ message }}
+    </div>
+    </div>`
+})
+export class BlockUIComponent {
+    message: any = 'Reloading Config...';
+
+}

--- a/src/common/blockui/blockui-service.ts
+++ b/src/common/blockui/blockui-service.ts
@@ -1,0 +1,34 @@
+import { Injectable, ApplicationRef, ViewContainerRef, Component, ComponentRef, ComponentFactoryResolver, ComponentFactory, ViewChild } from '@angular/core';
+
+import { BlockUIComponent } from './blockui-component'; // error here, wrong path
+
+
+@Injectable()
+export class BlockUIService {
+    blockComp: ComponentRef<any>;
+
+    constructor(private _appRef: ApplicationRef, private _resolver: ComponentFactoryResolver) {
+    }
+
+    public start(placeholder, prop) { // placeholder missing!
+        //let elementRef: ViewContainerRef = (<any>this._appRef)['_rootComponents'][0].location; // remove this
+        let elementRef = placeholder; // add this
+        return this.startInside(elementRef, null, prop);
+    }
+
+    public setProperty(prop) {
+      this.blockComp.instance.state.message = prop;
+    }
+
+    public startInside(elementRef: ViewContainerRef, anchorName: string, prop? : string) {
+        let factory = this._resolver.resolveComponentFactory(BlockUIComponent);
+        this.blockComp = elementRef.createComponent(factory);
+        prop ? this.blockComp.instance.message = prop : 'Please wait...';
+    }
+
+    public stop() {
+        if (this.blockComp) {
+            this.blockComp.destroy();
+        }
+    }
+}

--- a/src/common/blockui/blockui.css
+++ b/src/common/blockui/blockui.css
@@ -1,0 +1,19 @@
+.block-overlay {
+  background-color: rgba(255, 255, 255, 0.7);
+  cursor: wait;
+}
+.block-message-container {
+  position: absolute;
+  top: 35%;
+  left: 0;
+  right: 0;
+  height: 0;
+  text-align: center;
+  z-index: 10001;
+  cursor: wait;
+}
+.block-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/common/test-connection-modal.ts
+++ b/src/common/test-connection-modal.ts
@@ -5,6 +5,7 @@ import { SnmpDeviceService } from '../snmpdevice/snmpdevicecfg.service';
 import { SnmpMetricService } from '../snmpmetric/snmpmetriccfg.service';
 import { InfluxMeasService } from '../influxmeas/influxmeascfg.service';
 import { MeasFilterService } from '../measfilter/measfiltercfg.service';
+import { IMultiSelectOption, IMultiSelectSettings, IMultiSelectTexts } from './multiselect-dropdown';
 
 
 import {SpinnerComponent} from '../common/spinner';
@@ -43,6 +44,16 @@ import { Subscription } from "rxjs";
                       <input type="radio" class=""  (click)="selectOption('OID')" [checked]="selectedOption === 'OID'">Direct OID
                     </label>
                     </div>
+
+                    <div class="col-md-3">
+
+                    <label class="checkbox-inline">
+                      <input type="radio" class="btn btn-default" (click)="selectOption('Test')"   [checked]="selectedOption === 'Test'">Test
+                    </label>
+                    <ss-multiselect-dropdown [options]="selectmeas" [texts]="myTexts" [settings]="mySettings" [(ngModel)]="selectedmeas" (ngModelChange)="testi($event,selectmeas)"></ss-multiselect-dropdown>
+                    </div>
+
+
                     <div class="col-md-3">
 
                     <label class="checkbox-inline">
@@ -174,6 +185,7 @@ export class TestConnectionModal implements OnInit  {
 
   //ConnectionForm
   testForm : any;
+  test : any;
 
   public validationClick(myId: string):void {
     this.validationClicked.emit(myId);
@@ -189,6 +201,20 @@ export class TestConnectionModal implements OnInit  {
     });
 
   }
+
+testi(test,test2) {
+    for (let item of test2) {
+     if (item.id === test) {
+         this.selectOID(item.OID,null);
+         break;
+     }
+ }
+}
+
+testo: any;
+
+  selectmeas: any = [];
+
 
   //History OIDs
   histArray : Array<string> = [];
@@ -217,6 +243,10 @@ export class TestConnectionModal implements OnInit  {
   queryResult : any;
   editResults: boolean = false;
   maximized : boolean = false;
+
+  private mySettings: IMultiSelectSettings = {
+      singleSelect: true,
+  };
 
   selectOption(id : string) {
     this.selectedOption = id;
@@ -271,6 +301,11 @@ export class TestConnectionModal implements OnInit  {
     this.myObservable = this.influxMeasService.getMeas(null)
     .subscribe(
       data => {
+          this.selectmeas = [];
+          for (let entry of data) {
+            console.log(entry)
+            this.selectmeas.push({ 'id': entry.ID, 'name': entry.ID, 'OID': entry.IndexOID});
+          }
         for (let entry of data) {
           if (entry.IndexOID !== "") this.measlist.push({'ID' : entry.ID , 'OID' : entry.IndexOID});
         }

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -1,3 +1,4 @@
+<div #myspinner></div>
 <div id="wrapper">
   <!-- Sidebar -->
   <div id="sidebar-wrapper">
@@ -10,7 +11,13 @@
         <a (click)="clickMenu(menuItem.selector)" role="button" [ngClass]="item_type === menuItem.selector ? 'active-menu' : ''">{{menuItem.title}}</a>
       </li>
       <li class="last-li">
-        <a class="btn btn-primary" style="text-align:left" (click)="reloadConfig()"> <i class="glyphicon glyphicon-refresh" style="display: inline; padding-left: 0px"> </i>Reload Config</a>
+        <a class="btn btn-primary" style="text-align:left" (click)="reloadConfig()"> <i class="glyphicon glyphicon-refresh" style="display: inline; padding-left: 0px"> </i>Reload Config
+          <i *ngIf="elapsedReload" class="glyphicon glyphicon-ok-circle" container="body" [tooltip]="elapsed"></i>
+            <template #elapsed>
+              <p>Elapsed: {{elapsedReload}} ns</p>
+              <p>Last Reload: {{lastReload}}</p>
+            </template>
+        </a>
       </li>
       <li>
         <a class="btn btn-primary" style="text-align:left" role="button" (click)="logout()"><i class="glyphicon glyphicon-off" style="display: inline; padding-left: 0px"> </i>Logout</a>

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -1,4 +1,4 @@
-<div #myspinner></div>
+<div #blocker></div>
 <div id="wrapper">
   <!-- Sidebar -->
   <div id="sidebar-wrapper">

--- a/src/home/home.ts
+++ b/src/home/home.ts
@@ -1,18 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild,ViewContainerRef } from '@angular/core';
 import { NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
 import { Router } from '@angular/router';
 import { HttpAPI} from '../common/httpAPI';
 import { Observable } from 'rxjs/Observable';
+import { BlockUIService } from '../common/blockui/blockui-service';
+import { BlockUIComponent } from '../common/blockui/blockui-component'; // error
 
 declare var _:any;
 
 @Component({
   selector: 'home',
   templateUrl: './home.html',
-  styleUrls: [ './home.css' ]
+  styleUrls: [ './home.css' ],
+  providers: [BlockUIService]
 })
 
 export class Home {
+
+  @ViewChild('myspinner', { read: ViewContainerRef }) container: ViewContainerRef;
 
   response: string;
   api: string;
@@ -29,8 +34,10 @@ export class Home {
   {'title': 'SNMP Devices', 'selector' : 'snmpdevice'},
   {'title': 'Runtime', 'selector' : 'runtime'},
   ];
+  elapsedReload: string = '';
+  lastReload: Date;
 
-  constructor(public router: Router, public httpAPI: HttpAPI) {
+  constructor(public router: Router, public httpAPI: HttpAPI, private _blocker: BlockUIService) {
     this.item_type= "runtime";
     this.getFooterInfo();
   }
@@ -54,12 +61,16 @@ export class Home {
   }
 
   reloadConfig() {
+    this._blocker.start(this.container, "Reloading Conf. Please wait...");
     this.httpAPI.get('/api/rt/agent/reload/')
     .subscribe(
     response => {
-      alert(response.json())
+      this.lastReload = new Date();
+      this.elapsedReload = response.json();
+      this._blocker.stop();
     },
     error => {
+      this._blocker.stop();
       alert(error.text());
       console.log(error.text());
     }

--- a/src/home/home.ts
+++ b/src/home/home.ts
@@ -17,7 +17,7 @@ declare var _:any;
 
 export class Home {
 
-  @ViewChild('myspinner', { read: ViewContainerRef }) container: ViewContainerRef;
+  @ViewChild('blocker', { read: ViewContainerRef }) container: ViewContainerRef;
 
   response: string;
   api: string;

--- a/src/main.module.ts
+++ b/src/main.module.ts
@@ -15,7 +15,7 @@ import { Login } from './login/login';
 import { App } from './app/app';
 import { HttpAPI } from './common/httpAPI';
 
-import { routes } from './app/app.routes';
+import { AppRoutes } from './app/app.routes';
 //common
 import { ControlMessagesComponent } from './common/control-messages.component';
 import { MultiselectDropdownModule } from './common/multiselect-dropdown'
@@ -30,6 +30,7 @@ import { MeasFilterCfgComponent } from './measfilter/measfiltercfg.component';
 import { InfluxServerCfgComponent } from './influxserver/influxservercfg.component';
 import { RuntimeComponent } from './runtime/runtime.component';
 import { CustomFilterCfgComponent } from './customfilter/customfiltercfg.component';
+import { BlockUIService } from './common/blockui/blockui-service';
 
 import { AccordionModule , PaginationModule ,TabsModule } from 'ng2-bootstrap';
 import { TooltipModule } from 'ng2-bootstrap';
@@ -45,7 +46,9 @@ import { ValidationService } from './common/validation.service';
 //pipes
 import { ObjectParserPipe } from './common/custom_pipe';
 
+import { BlockUIComponent } from './common/blockui/blockui-component';
 import { SpinnerComponent } from './common/spinner';
+
 
 @NgModule({
   bootstrap: [App],
@@ -62,6 +65,7 @@ import { SpinnerComponent } from './common/spinner';
     CustomFilterCfgComponent,
     RuntimeComponent,
     GenericModal,
+    BlockUIComponent,
     SpinnerComponent,
     TestConnectionModal,
     TestFilterModal,
@@ -82,13 +86,13 @@ import { SpinnerComponent } from './common/spinner';
     TabsModule.forRoot(),
     DropdownModule.forRoot(),
     Ng2TableModule,
-    RouterModule.forRoot(routes, {
-    //  useHash: true
-    })
+    RouterModule.forRoot(AppRoutes)
   ],
   providers: [
     HttpAPI,
     ValidationService,
-  ]
+    BlockUIService
+  ],
+  entryComponents: [BlockUIComponent]
 })
 export class AppModule {}


### PR DESCRIPTION
## Feature

- Added UI Blocker, applied when the user clicks on reload-conf button.

It will appear a spinner
![image](https://cloud.githubusercontent.com/assets/13196237/22797599/255aca70-eeff-11e6-94db-8c90369da029.png)

-  Added better description of reload conf:
When reload conf  finishes, the elapsed time and the last reload appears on tooltip/icon on reload config button

![image](https://cloud.githubusercontent.com/assets/13196237/22797639/494d2fa4-eeff-11e6-832a-e2b676990afe.png)


## Fix

- Fixed routes
Now the user is not redirected to login when setting home or base href, instead, it reloads to /home.


