### PR TITLE
UI Add singleselect on Test Connection Modal, minor fixes and enhancements

### DIFF
--- a/src/influxmeas/influxmeascfg.service.ts
+++ b/src/influxmeas/influxmeascfg.service.ts
@@ -68,6 +68,13 @@ export class InfluxMeasService {
             responseData.json()
     )};
 
+    getMeasByType(type : string) {
+        // return an observable
+        return this.httpAPI.get('/api/cfg/measurement/type/'+type)
+        .map( (responseData) =>
+            responseData.json()
+    )};
+
     checkOnDeleteInfluxMeas(id : string){
       return this.httpAPI.get('/api/cfg/measurement/checkondel/'+id)
       .map( (responseData) =>


### PR DESCRIPTION
## Features
- Added single select on test connection modal
- Split measurements on indexed and inderect indexed

## Fixes
- Correctly unsubscribe controlling hide buttons
- Added OID condition instead of deprecated filters condOID

## Enhances
- Now all the selectable values are loaded only when the user select  its parent, it instead of loading all of them on the initialisation of the component