### PR TITLE
UI Fix refresh value when changing between field types with the same form name

### DIFF
--- a/src/common/multiselect-dropdown.ts
+++ b/src/common/multiselect-dropdown.ts
@@ -190,6 +190,8 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
                     this.updateTitle();
                 }
             }
+        } else {
+            this.title = this.texts.defaultTitle;
         }
     }
 

--- a/src/measfilter/measfiltercfg.component.ts
+++ b/src/measfilter/measfiltercfg.component.ts
@@ -238,8 +238,7 @@ export class MeasFilterCfgComponent {
     this.measFilterService.getMeasFilterById(id)
       .subscribe(data => {
         this.testmeasfilters = data;
-        console.log(this.testmeasfilters.FType);
-        this.initFilterType(row.FType)
+        this.initFilterType(row.FType, false);
         this.editmode = "modify"
       },
       err => console.error(err),
@@ -303,9 +302,10 @@ export class MeasFilterCfgComponent {
       );
   }
 
-  initFilterType(type) {
+  initFilterType(type : string, init? : boolean) : void {
+    if (init === true) this.measfilterForm.controls['FilterName'].patchValue(null);
     if (type === 'CustomFilter') {
-      this.getCustomFiltersforMeasFilters()
+      this.getCustomFiltersforMeasFilters();
     }
     if (type === 'OIDCondition') {
       this.getOidCond()

--- a/src/measfilter/measfiltereditor.html
+++ b/src/measfilter/measfiltereditor.html
@@ -55,7 +55,7 @@
 				<label class="control-label col-sm-2" for="FType">Filter type</label>
 				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Filter input source: file or condiction OID"></i>
 				<div class="col-sm-9">
-					<select formControlName="FType" id="FType" (click)="initFilterType(measfilterForm.controls.FType.value)">
+					<select formControlName="FType" id="FType" (click)="initFilterType(measfilterForm.controls.FType.value, true)">
 						<option value="file">File</option>
 						<option value="OIDCondition">OID Condition</option>
 						<option value="CustomFilter" >Custom Filter</option>
@@ -161,7 +161,7 @@
 				<label class="control-label col-sm-2" for="FType">Filter type</label>"
 				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Filter input source: file or condiction OID"></i>
 				<div class="col-sm-9">
-					<select formControlName="FType" id="FType" [ngModel]="testmeasfilters.FType" (click)="initFilterType(measfilterForm.controls.FType.value)">
+					<select formControlName="FType" id="FType" [ngModel]="testmeasfilters.FType" (click)="initFilterType(measfilterForm.controls.FType.value, true)">
 						<option value="file">File</option>
 						<option value="OIDCondition">OID Condition</option>
 						<option value="CustomFilter" >Custom Filter</option>

--- a/src/snmpmetric/snmpmetriceditor.html
+++ b/src/snmpmetric/snmpmetriceditor.html
@@ -55,7 +55,7 @@
         <label class="control-label col-sm-2" for="DataSrcType">DataSrcType</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
         <div class="col-sm-9">
-          <select formControlName="DataSrcType" id="DataSrcType" (click)=" snmpmetForm.controls.DataSrcType.value === 'CONDITIONEVAL' ? getOidCond() : '' ">
+          <select formControlName="DataSrcType" id="DataSrcType" (click)="snmpmetForm.controls['ExtraData'].patchValue(null); snmpmetForm.controls.DataSrcType.value === 'CONDITIONEVAL' ? getOidCond() : null ">
             <option value="INTEGER">(SNMP SMI Type) INTEGER</option>
             <option value="Integer32">(SNMP SMI Type) Integer32</option>
             <option value="Gauge32">(SNMP SMI Type) Gauge32</option>
@@ -190,7 +190,7 @@
         <label class="control-label col-sm-2" for="DataSrcType">DataSrcType</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
         <div class="col-sm-9">
-          <select formControlName="DataSrcType" id="DataSrcType" [ngModel]="testsnmpmetric.DataSrcType" (click)=" snmpmetForm.controls.DataSrcType.value === 'CONDITIONEVAL' ? getOidCond() : '' ">
+          <select formControlName="DataSrcType" id="DataSrcType" [ngModel]="testsnmpmetric.DataSrcType" (click)="snmpmetForm.controls['ExtraData'].patchValue(null); snmpmetForm.controls.DataSrcType.value === 'CONDITIONEVAL' ? getOidCond() : '' ">
             <option value="INTEGER">(SNMP SMI Type) INTEGER</option>
             <option value="Integer32">(SNMP SMI Type) Integer32</option>
             <option value="Gauge32">(SNMP SMI Type) Gauge32</option>


### PR DESCRIPTION
Seems we didn't check if the user changes some dependant fields witht the same form name, as the metric datasource type or metric type.

When the user changes between those fields, the value remained on the formname. Now it resets unless they are loaded from edit or new with previous data.