### PR TITLE
UI Fix DB relation update when deleting a customfilter or oidcondition on relational components

### DIFF
--- a/pkg/webui/webserver.go
+++ b/pkg/webui/webserver.go
@@ -905,7 +905,7 @@ func AddMeasFilter(ctx *Context, dev config.MeasFilterCfg) {
 		//no need for check here we have needed  SNMP walk function defined at this level
 	case "CustomFilter":
 		f := filter.NewCustomFilter(dev.FilterName, dev.EnableAlias, log)
-		err := f.Init(agent.MainConfig.Database)
+		err := f.Init(&agent.MainConfig.Database)
 		if err != nil {
 			ctx.JSON(404, err.Error())
 			return

--- a/src/customfilter/test-filter-modal.ts
+++ b/src/customfilter/test-filter-modal.ts
@@ -267,7 +267,7 @@ export class TestFilterModal implements OnInit {
       id: ['', Validators.required],
       IDMeasurementCfg: [''],
       FType: ['CustomFilter'],
-      CustomID: [''],
+      FilterName: [''],
       EnableAlias: ['false'],
       Description: ['']
     });

--- a/src/customfilter/testingfilter.html
+++ b/src/customfilter/testingfilter.html
@@ -57,11 +57,11 @@
               </div>
 
               <div class="form-group">
-                <label class="control-label col-sm-2" for="CustomID">CustomID</label>
+                <label class="control-label col-sm-2" for="FilterName">CustomID</label>
                 <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="A valid OID to filter by"></i>
                 <div class="col-sm-9">
-                  <input readonly formControlName="CustomID" [ngModel]="customFilterValues.ID">
-                  <control-messages [control]="newFilterForm.controls.CustomID"></control-messages>
+                  <input readonly formControlName="FilterName" [ngModel]="customFilterValues.ID">
+                  <control-messages [control]="newFilterForm.controls.FilterName"></control-messages>
                 </div>
               </div>
               <div class="form-group">


### PR DESCRIPTION
Seems we missed some changes on DB relation when unified the filter names on the single  filter_name  field. This PR fixes:

- Custom filter binds correctly to the measurement filter
- Custom fiilter are deleted correctly from the relational components (measurement filters)
- OIDCond are deleted correctly from the relational components (measurement filters, metric with condeval)