### PR TITLE
UI Fix base OID hidden field when DataSrcType is STRINGPARSER

### DIFF
--- a/src/snmpmetric/snmpmetriccfg.component.ts
+++ b/src/snmpmetric/snmpmetriccfg.component.ts
@@ -113,6 +113,7 @@ export class SnmpMetricCfgComponent {
         controlArray.push({'ID': 'ExtraData', 'defVal' : '', 'Validators' : Validators.required, 'override' : override });
         break;
       case 'STRINGPARSER':
+        controlArray.push({'ID': 'BaseOID', 'defVal' : '', 'Validators' : Validators.compose([ValidationService.OIDValidator, Validators.required]) })
       case 'STRINGEVAL':
         controlArray.push({'ID': 'ExtraData', 'defVal' : '', 'Validators' : Validators.required, 'override' : override });
         controlArray.push({'ID': 'Scale', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })


### PR DESCRIPTION
It seems that we missed BaseOID field when DataSrcType is STRINGPARSER