### PR TITLE
UI Fix hide runtime options if the device is not connected, fixes #182

### DIFF
--- a/src/runtime/runtimeview.html
+++ b/src/runtime/runtimeview.html
@@ -35,8 +35,8 @@
     <span>Tags: <label style="margin-left: 10px" class="label label-info" *ngFor="let tag of runtime_dev['TagMap'] | objectParser"> {{tag.key}}:{{tag.value}}</label> </span>
 
     <hr>
-    <div class="row" *ngIf="runtime_dev['DeviceConnected'] !== false">
-      <div class="col-md-6">
+    <div class="row">
+      <div class="col-md-6" *ngIf="runtime_dev['DeviceConnected'] !== false">
         <div class="panel panel-default">
           <div class="panel-heading">SysInfo</div>
           <div class="panel-body" style="overflow-x: scroll !important">


### PR DESCRIPTION
## Fixes
- Fix hidden runtime options if the device is not connected. This PR allows the user to change rt options even the device is not connected. Fixes #182 

![image](https://cloud.githubusercontent.com/assets/13196237/25242257/4b5d97a8-25f9-11e7-87f5-b2e195665170.png)
