### PR TITLE
UI Add  TagMap and SysDesc as new columns on runtime table

### DIFF
--- a/pkg/agent/device/snmpdevice.go
+++ b/pkg/agent/device/snmpdevice.go
@@ -113,10 +113,16 @@ func (d *SnmpDevice) getBasicStats() *DevStat {
 	}
 	stat := d.stats.ThSafeCopy()
 	stat.ReloadLoopsPending = d.ReloadLoopsPending
+	stat.TagMap = d.TagMap
 	stat.DeviceActive = d.DeviceActive
 	stat.DeviceConnected = d.DeviceConnected
 	stat.NumMeasurements = len(d.Measurements)
 	stat.NumMetrics = sum
+	if d.SysInfo != nil {
+		stat.SysDescription = d.SysInfo.SysDescr
+	} else {
+		stat.SysDescription = ""
+	}
 	return stat
 }
 

--- a/pkg/agent/device/stats.go
+++ b/pkg/agent/device/stats.go
@@ -38,7 +38,7 @@ const (
 type DevStat struct {
 	//ID
 	id     string
-	tagMap map[string]string
+	TagMap map[string]string
 	//Control
 	log     *logrus.Logger
 	selfmon *selfmon.SelfMon
@@ -53,6 +53,7 @@ type DevStat struct {
 	DeviceConnected    bool
 	//extra measurement statistics
 	NumMeasurements int
+	SysDescription  string
 	NumMetrics      int
 }
 
@@ -61,7 +62,7 @@ func (s *DevStat) Init(id string, tm map[string]string, l *logrus.Logger) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.id = id
-	s.tagMap = tm
+	s.TagMap = tm
 	s.log = l
 	s.Counters = make([]interface{}, DevStatTypeSize)
 	s.Counters[SnmpGetQueries] = 0
@@ -141,7 +142,7 @@ func (s *DevStat) ThSafeCopy() *DevStat {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	st := &DevStat{}
-	st.Init(s.id, s.tagMap, s.log)
+	st.Init(s.id, s.TagMap, s.log)
 	for k, v := range s.Counters {
 		st.Counters[k] = v
 	}
@@ -156,7 +157,7 @@ func (s *DevStat) Send() {
 	s.log.Infof("STATS SNMP FILTER: filter pooling took [%f seconds] ", s.Counters[FilterDuration])
 	s.log.Infof("STATS INFLUX: influx send took [%f seconds]", s.Counters[BackEndSentDuration])
 	if s.selfmon != nil {
-		s.selfmon.AddDeviceMetrics(s.id, s.getMetricFields(), s.tagMap)
+		s.selfmon.AddDeviceMetrics(s.id, s.getMetricFields(), s.TagMap)
 	}
 }
 

--- a/src/common/ng-table/components/table/ng-table.component.ts
+++ b/src/common/ng-table/components/table/ng-table.component.ts
@@ -58,7 +58,7 @@ import { ElapsedSecondsPipe } from '../../../elapsedseconds.pipe';
 					<i class="glyphicon glyphicon-edit"  [tooltip]="'Edit item'" (click)="editItem(row)"></i>
     			<i class="glyphicon glyphicon glyphicon-remove"  [tooltip]="'Remove Item'" (click)="removeItem(row)"></i>
           </td>
-          <td *ngIf="showStatus == true">
+          <td *ngIf="showStatus == true" style="min-width: 170px">
           <label style="display: inline; margin-right: 2px" container="body" [tooltip]="'View '+ row.ID" class="label label-primary glyphicon glyphicon-eye-open" (click)="viewItem(row)"></label>
           <span style="border-right: 1px solid #1B809E; padding-right: 6px">
           <label style="display: inline; margin-right: 2px" container="body" [tooltip]="'Test connection '+ row.ID" class="label label-primary glyphicon glyphicon glyphicon-flash" (click)="testConnection(row)"></label>

--- a/src/runtime/runtime.component.ts
+++ b/src/runtime/runtime.component.ts
@@ -38,6 +38,8 @@ export class RuntimeComponent implements OnDestroy {
 
   public rt_columns: Array<any> = [
     { title: 'ID', name: 'ID'},
+    { title: 'TagMap', name: 'TagMap',tooltip: 'Num Measurements configured'},
+    { title: 'SysDesc', name: 'SysDescription'},
     { title: '#Meas', name: 'NumMeasurements',tooltip: 'Num Measurements configured'},
     { title: '#Metrics', name: 'NumMetrics'},
     { title: 'Get.Errs' ,name:'Counter7',tooltip: 'SnmpOIDGetErrors:number of  oid with errors for all measurements '},
@@ -329,7 +331,6 @@ export class RuntimeComponent implements OnDestroy {
   }
 
   loadRuntimeById(id: string, selectedMeas: number) {
-    console.log(this.isRequesting);
     this.mySubscription = this.runtimeService.getRuntimeById(id)
       .subscribe(
       data => {

--- a/src/runtime/runtime.service.ts
+++ b/src/runtime/runtime.service.ts
@@ -33,6 +33,12 @@ export class RuntimeService {
                              i++;
                          }
                      } else tmp[key] = val;
+                     if (key == "TagMap") {
+                         tmp['TagMap']=[];
+                         for (let a in val) {
+                             tmp['TagMap'].push(a+'='+val[a])
+                         }
+                     }
                   });
                   result.push(tmp);
                   //result.push({'ID': key, 'value' :value});

--- a/src/runtime/runtimeview.html
+++ b/src/runtime/runtimeview.html
@@ -1,6 +1,8 @@
 <h2>Runtime</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
+<test-connection-modal #viewTestConnectionModal titleName='Test connection for:'>
+</test-connection-modal>
 <p [ngSwitch]="editmode">
   <template ngSwitchCase="list">
   <div class="row">
@@ -18,8 +20,6 @@
     </div>
   </div>
   <br>
-  <test-connection-modal #viewTestConnectionModal titleName='Test connection for:'>
-  </test-connection-modal>
   <my-spinner [isRunning]="isRequesting"></my-spinner>
   <ng-table *ngIf="isRequesting === false" [config]="config" (tableChanged)="onChangeTable(config)" (extraActionClicked)="onExtraActionClicked($event)" (viewedItem)="initRuntimeInfo($event.ID,null, true)" (editedItem)="editMeasGroup($event)" (removedItem)="removeItem($event)" (testedConnection)="showTestConnectionModal($event)" [showCustom]="false" [showStatus]="true" [rows]="rows" [columns]="rt_columns" [extraActions]="extraActions">
   </ng-table>
@@ -35,6 +35,7 @@
     <div class="well">
       <label [tooltip]="'Back to list'" container="body" style="font-size:130%; margin-top:10px; border-right: 1px solid; padding-right: 5px;"><i class="text-primary glyphicon glyphicon-tasks" (click)="reloadData()"></i></label>
       <label [tooltip]="'Refresh'" container="body" style="margin-top:10px; font-size:130%; border-right: 1px solid; padding-right: 5px;"><i class="glyphicon glyphicon-refresh" (click)="initRuntimeInfo(runtime_dev.ID,measActive)"></i></label>
+      <label [tooltip]="'Test Connection'" container="body" style="margin-top:10px; font-size:130%; border-right: 1px solid; padding-right: 5px;"><i [ngClass]="runtime_dev['DeviceConnected'] === false ? ['text-danger glyphicon glyphicon-flash'] : ['text-warning glyphicon glyphicon-flash']" (click)="showTestConnectionModal(runtime_dev)"></i></label>
 
         <h4 style="display:inline; border-right: 1px solid; padding-right: 5px" [ngClass]="runtime_dev['DeviceConnected'] === false ? 'text-danger' : 'text-success' ">{{runtime_dev.ID}}</h4>
         <h4 *ngIf="runtime_dev['DeviceConnected'] == false" class="text-danger" style="display:inline; border-right: 1px solid; padding-right: 5px;"> Device is not connected</h4>
@@ -44,7 +45,7 @@
     <div class="row">
       <div class="col-md-6" *ngIf="runtime_dev['DeviceConnected'] !== false">
         <div class="panel panel-default">
-          <div class="panel-heading">SysInfo</div>
+          <div class="panel-heading"><span class="text-primary glyphicon glyphicon-info-sign" style="margin-top: 2px; margin-right: 10px"></span>SysInfo</div>
           <div class="panel-body" style="overflow-x: scroll !important">
             <table class="table-striped table-bordered">
               <tr *ngFor="let info of runtime_dev['SysInfo'] | objectParser">
@@ -55,7 +56,7 @@
           </div>
         </div>
         <div class="panel panel-default">
-          <div class="panel-heading">Statistics SNMP Device</div>
+          <div class="panel-heading"><span class="text-primary glyphicon glyphicon-dashboard" style="margin-top: 2px; margin-right: 10px"></span>Statistics SNMP Device</div>
           <div class="panel-body">
             <table class="table-striped table-bordered">
               <tr>
@@ -77,7 +78,7 @@
       </div>
       <div class="col-md-6">
         <div class="panel panel-default" style="padding-bottom: 0px">
-          <div class="panel-heading">Runtime Operations</div>
+          <div class="panel-heading"><span class="text-primary glyphicon glyphicon-cog" style="margin-top: 2px; margin-right: 10px"></span>Runtime Operations</div>
           <div class="panel-body">
             <ul class="list-group">
               <!--  Device Gather Process State -->


### PR DESCRIPTION
## Enhances

- Add new columns on `Runtime` table - `TagMap` and `SysDesc`. This will allow the user to make accurate filter of configured devices to see its behaviour 

![image](https://user-images.githubusercontent.com/13196237/27277818-d7831be4-54df-11e7-993c-124afc3e9538.png)

- Add `Test Connection` button  on device runtime view

![image](https://user-images.githubusercontent.com/13196237/27277909-26a29312-54e0-11e7-818f-e5ed4d7d7041.png)


