### PR TITLE
Fix unable to test connection on runtime tables due to null SystemOIDs

### DIFF
--- a/pkg/data/snmp/snmp.go
+++ b/pkg/data/snmp/snmp.go
@@ -638,7 +638,7 @@ func GetClient(s *config.SnmpDeviceCfg, l *logrus.Logger, meas string, debug boo
 	}
 	//first snmp query
 
-	if len(s.SystemOIDs) > 0 && len(s.SystemOIDs[0]) > 0 {
+	if len(s.SystemOIDs) > 0 && len(s.SystemOIDs[0]) > 0 && s.SystemOIDs[0] != "null" {
 		l.Infof("Detected alternate %d SystemOID's ", len(s.SystemOIDs))
 		// this device has an alternate System Description (Non MIB-2 based systems)
 		si, err := SnmpGetAlternateSysInfo(s.ID, client, l, s.SystemOIDs)


### PR DESCRIPTION
## Fix

- Fix #254 adding a new validation to skip SystemOIDs when the field is set as [null] by XORM engine