### PR TITLE
UI - Minor fixes on SNMPDevice DeviceTagValue and CustomFilter - filter creation modal

### DIFF
--- a/src/customfilter/test-filter-modal.ts
+++ b/src/customfilter/test-filter-modal.ts
@@ -84,6 +84,7 @@ export class TestFilterModal implements OnInit {
 
   newCustomFilter(formValues? : any) {
     //Reset forms!
+    this.showNewFilterForm = false;
     this.mode = "new";
     this.clearQuery();
     this.clearItems();

--- a/src/snmpdevice/snmpdeviceeditor.html
+++ b/src/snmpdevice/snmpdeviceeditor.html
@@ -293,7 +293,7 @@
         <div class="col-sm-9">
           <select formControlName="DeviceTagValue" id="DeviceTagValue">
             <option selected="selected" value="id">Id - {{snmpdevForm.controls.ID.value}}</option>
-            <option value="name">Host - {{snmpdevForm.controls.Host.value}}</option>
+            <option value="host">Host - {{snmpdevForm.controls.Host.value}}</option>
           </select>
           <control-messages [control]="snmpdevForm.controls.DeviceTagValue"></control-messages>
         </div>
@@ -618,7 +618,7 @@
         <div class="col-sm-9">
           <select formControlName="DeviceTagValue" id="DeviceTagValue" [ngModel]="snmpdevForm.value.DeviceTagValue">
             <option selected="selected" value="id">Id - {{snmpdevForm.controls.ID.value}}</option>
-            <option value="name">Host - {{snmpdevForm.controls.Host.value}}</option>
+            <option value="host">Host - {{snmpdevForm.controls.Host.value}}</option>
           </select>
           <control-messages [control]="snmpdevForm.controls.DeviceTagValue"></control-messages>
         </div>


### PR DESCRIPTION
## Fixes

- Fix on SNMPDevice when DeviceTagValue was set with host, the UI was sending a request with value "name" instead of "host", so it was skipped by the SNMPCollector and was sending the tag with the `ID`

- Fix on CustomFilter modal when trying to create another field after cancelling a Filter Creation. It didn't reset the var so the modal was stuck on the frontend
