### PR TITLE
UI Replace event.srcElement for event.target due to FF incompatibility 

### DIFF
--- a/src/common/dataservice/import-file-modal.ts
+++ b/src/common/dataservice/import-file-modal.ts
@@ -144,7 +144,7 @@ export class ImportFileModal {
   }
 
   selectFile(event) {
-    if (event.srcElement.files.length != 0) this.files = event.srcElement.files;
+    if (event.target.files.length != 0) this.files = event.target.files;
     else this.files = null;
   }
 


### PR DESCRIPTION
## Fixes

- Replaced event.srcElement for event.target due to FF incompatibility. This PR fixes #258 
