### PR TITLE
UI Add filters by status on Runtime device table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### fixes
 
-* fix for #247, #249, #254, #258, #256 (PR)
+* fix for #247, #249, #254, #258, #256 (PR), #260
 
 ### breaking changes
 

--- a/src/runtime/runtime.component.ts
+++ b/src/runtime/runtime.component.ts
@@ -1,3 +1,4 @@
+
 import { ChangeDetectionStrategy, Component, ViewChild, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { FormBuilder, Validators} from '@angular/forms';
 import { RuntimeService } from './runtime.service';
@@ -93,8 +94,8 @@ export class RuntimeComponent implements OnDestroy {
   //TABLE
   // CHECK DATA, our data is array of arrays?!
   private data: Array<any> = [];
-  public activeDevices : any = [];
-
+  public activeDevices : number;
+  public noConnectedDevices : number;
   public dataTable: Array<any> = [];
   public finalData: Array<Array<any>> = [];
   public columns: Array<any> = [];
@@ -114,6 +115,9 @@ export class RuntimeComponent implements OnDestroy {
   public numPages: number = 1;
   public length: number = 0;
   public myFilterValue: any;
+  public activeFilter: boolean = false;
+  public deactiveFilter: boolean = false;
+  public noConnectedFilter  : boolean = false;
 
   //Set config
   public config: any = {
@@ -227,6 +231,7 @@ export class RuntimeComponent implements OnDestroy {
     this.rows = page && this.config.paging ? this.changePage(page, sortedData) : sortedData;
     this.length = sortedData.length;
     this.activeDevices = sortedData.filter((item) => {return item.DeviceActive}).length
+    this.noConnectedDevices = sortedData.filter((item) => { if(item.DeviceActive === true && item.DeviceConnected  === false) return true }).length
   }
 
   public onExtraActionClicked(data:any) {
@@ -514,11 +519,37 @@ export class RuntimeComponent implements OnDestroy {
         this.data = this.runtime_devs;
         this.config.sorting.columns=this.columns,
         this.isRequesting = false;
+        this.activeFilter = this.deactiveFilter = this.noConnectedFilter = false;
         this.onChangeTable(this.config);
       },
       err => console.error(err),
       () => console.log('DONE')
       );
+  }
+
+  toogleActiveFilter(option : string) {
+    if (this.activeFilter === false && option === 'active') {
+      this.noConnectedFilter = false;
+      this.deactiveFilter = false;
+      this.activeFilter = true;
+      this.data = this.runtime_devs.filter((item) => { if(item.DeviceActive === true) return true })
+    } else if (this.deactiveFilter === false && option === 'deactive' ) {
+      this.noConnectedFilter = false;
+      this.activeFilter = false;
+      this.deactiveFilter = true;
+      this.data = this.runtime_devs.filter((item) => { if(item.DeviceActive === false) return true })
+    } else if (this.noConnectedFilter === false && option === 'noconnected'){
+      this.noConnectedFilter = true;
+      this.activeFilter = false;
+      this.deactiveFilter = false;
+      this.data = this.runtime_devs.filter((item) => { if(item.DeviceConnected === false) return true })
+    } else {
+      this.data = this.runtime_devs;
+      this.noConnectedFilter = false;
+      this.activeFilter = false;
+      this.deactiveFilter = false;
+    }
+    this.onChangeTable(this.config);
   }
 
   ngOnDestroy() {

--- a/src/runtime/runtimeview.html
+++ b/src/runtime/runtimeview.html
@@ -6,20 +6,24 @@
 <p [ngSwitch]="editmode">
   <template ngSwitchCase="list">
   <div class="row">
-    <div class="col-md-8 text-left">
+    <div class="col-md-9 text-left">
       <label [tooltip]="'Refresh'" container="body" style="margin-top:10px; border-right: 1px solid; padding-right: 5px;"><i class="glyphicon glyphicon-refresh" (click)="reloadData()"></i></label>
       <label [tooltip]="'Clear Filter'" container="body" (click)="onResetFilter()" style="margin-top: 10px"><i class="glyphicon glyphicon-trash text-primary"></i></label>
       <input *ngIf="config.filtering" placeholder="Filter all columns" required = "false" [(ngModel)]="myFilterValue" [ngTableFiltering]="config.filtering" class="form-control select-pages" (tableChanged)="onChangeTable(config)" />
       <label style="font-size:100%" [ngClass]="length > 0 ? ['label label-info'] : ['label label-warning']">{{length}} Results</label>
-      <label style="font-size:100%" [ngClass]="['label label-success']">{{activeDevices}} Active</label>
-      <label style="font-size:100%" [ngClass]="['label label-danger']">{{length - activeDevices}} Deactived</label>
   </div>
-  <div class="col-md-4 text-right">
+  <div class="col-md-3 text-right">
       <span style="margin-left: 20px"> Items per page: </span>
       <select class="select-pages" style="width:auto" [ngModel]="itemsPerPage || 'All'" (ngModelChange)="changeItemsPerPage($event)">
         <option *ngFor="let option of itemsPerPageOptions" style="padding-left:2px" [value]="option.value">{{option.title}}</option>
       </select>
-    </div>
+  </div>
+  </div>
+  <div class="row well" *ngIf="isRequesting === false"  style="margin-top: 10px; padding: 10px 0px 10px 15px;">
+    <span> Status: </span>
+    <label style="font-size:100%" [ngClass]="['label label-success']" (click)="toogleActiveFilter('active')" container="body" tooltip="Filter actived devices">{{activeDevices}} Actived <i [ngClass]="activeFilter === true ? ['glyphicon glyphicon-ok'] : ['glyphicon glyphicon-unchecked']"></i></label>
+    <label style="font-size:100%;margin-left:15px" [ngClass]="['label label-danger']" (click)="toogleActiveFilter('deactive')" container="body" tooltip="Filter deactived devices">{{length - activeDevices}} Deactived <i [ngClass]="deactiveFilter === true ? ['glyphicon glyphicon-ok'] : ['glyphicon glyphicon-unchecked']"></i></label>
+    <label *ngIf="noConnectedDevices > 0" [ngClass]="['label label-warning']" style="margin-left:15px; font-size:100%" (click)="toogleActiveFilter('noconnected')" tooltip="Filter actived but no connected devices"><i class="glyphicon glyphicon-warning-sign"></i> Warning {{noConnectedDevices}} {{noConnectedDevices > 1 ? 'devices' : 'device'}} trying to connect... <i [ngClass]="noConnectedFilter === true ? ['glyphicon glyphicon-ok'] : ['glyphicon glyphicon-unchecked']"></i></label>
   </div>
   <br>
   <my-spinner [isRunning]="isRequesting"></my-spinner>


### PR DESCRIPTION
## Features

- Added filters by status on Runtime device table. This PR allows the user to filter the devices by `Actived`, `Deactived` and `Active but not connected`. Fixes #260 

![image](https://user-images.githubusercontent.com/13196237/30523448-9fa48f84-9be1-11e7-9d6e-df80c82bc45b.png)

Notes:
- In order to improve the filtering, the existing filter (input normal text) will be applied taking into account the new status filters
- The `Active but not connected` filter will only appear when some device meet the given condition.
