### PR TITLE
UI Simplified create and modify templates in one on all components

### DIFF
--- a/src/influxmeas/influxmeaseditor.html
+++ b/src/influxmeas/influxmeaseditor.html
@@ -1,7 +1,7 @@
 <h2>Influx Measurements</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='Measurements'></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this Measurement will affect the following components','Deleting this Measurement will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -33,14 +33,15 @@
     </pagination>
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
-  <template ngSwitchCase="create">
-    <form [formGroup]="influxmeasForm" class="form-horizontal" (ngSubmit)="saveInfluxMeas()">
+
+  <template ngSwitchDefault>
+    <form [formGroup]="influxmeasForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveInfluxMeas() : updateInfluxMeas()">
 
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of measurement"></i>
         <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
+          <input formControlName="ID" id="ID" [ngModel]="influxmeasForm.value.ID"/>
           <control-messages [control]="influxmeasForm.controls.ID"></control-messages>
         </div>
       </div>
@@ -48,7 +49,7 @@
       <div class="form-group">
         <label class="control-label col-sm-2" for="Name">Name</label> <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Measurement name used on InfluxDB server"></i>
         <div class="col-sm-9">
-          <input formControlName="Name" id="Name" />
+          <input formControlName="Name" id="Name" [ngModel]="influxmeasForm.value.Name"/>
           <control-messages [control]="influxmeasForm.controls.Name"></control-messages>
         </div>
       </div>
@@ -57,7 +58,7 @@
         <label class="control-label col-sm-2" for="GetMode">GetMode</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Different mode to get the values. On 'value' the measurement collects many values as fields have. On 'indexed' the measurement collects many values as many fields finds on the indexOID request"></i>
         <div class="col-sm-9">
-          <select formControlName="GetMode" id="GetMode" (click)="setDynamicFields(influxmeasForm.value.GetMode)">
+          <select formControlName="GetMode" id="GetMode" (click)="setDynamicFields(influxmeasForm.value.GetMode)" [ngModel]="influxmeasForm.value.GetMode">
             <option value="value">(snmp scalar) Direct Value</option>
             <option value="indexed">(snmp Table) Indexed with direct TAG</option>
             <option value="indexed_it">(snmp Table) Indexed with indirect TAG </option>
@@ -70,7 +71,7 @@
           <label class="control-label col-sm-2" for="IndexOID">IndexOID</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The index OID to get the all real OID's to query data"></i>
           <div class="col-sm-9">
-            <input formControlName="IndexOID" id="IndexOID" />
+            <input formControlName="IndexOID" id="IndexOID" [ngModel]="influxmeasForm.value.IndexOID"/>
             <control-messages [control]="influxmeasForm.controls.IndexOID"></control-messages>
           </div>
         </div>
@@ -79,7 +80,7 @@
             <label class="control-label col-sm-2" for="TagOID">TagOID</label>
             <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
             <div class="col-sm-9">
-              <input formControlName="TagOID" id="TagOID" />
+              <input formControlName="TagOID" id="TagOID" [ngModel]="influxmeasForm.value.TagOID"/>
               <control-messages [control]="influxmeasForm.controls.TagOID"></control-messages>
             </div>
           </div>
@@ -88,7 +89,7 @@
           <label class="control-label col-sm-2" for="IndexTag">IndexTag</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag name that will be sent after data gathered"></i>
           <div class="col-sm-9">
-            <input formControlName="IndexTag" id="IndexTag" />
+            <input formControlName="IndexTag" id="IndexTag" [ngModel]="influxmeasForm.value.IndexTag"/>
             <control-messages [control]="influxmeasForm.controls.IndexTag"></control-messages>
           </div>
         </div>
@@ -97,7 +98,7 @@
           <label class="control-label col-sm-2" for="IndexTag">IndexTagFormat</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag value will be sent parametrized with $IDX1 , $VAL1 (default $VAL1 on direct indexed) and $IDX2, $VAL2 (default $VAL2 on indirect indexed) "></i>
           <div class="col-sm-9">
-            <input formControlName="IndexTagFormat" id="IndexTagFormat" />
+            <input formControlName="IndexTagFormat" id="IndexTagFormat" [ngModel]="influxmeasForm.value.IndexTagFormat"/>
             <control-messages [control]="influxmeasForm.controls.IndexTagFormat"></control-messages>
           </div>
         </div>
@@ -106,7 +107,7 @@
           <label class="control-label col-sm-2" for="IndexAsValue">IndexAsValue</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="If set to true the value for the TAG will be the indexnum , else will be the value , remember in SNMP Indexed Tables we will get data on this form snmpget(IndexOID.Indexnum) = value "></i>
           <div class="col-sm-9">
-            <select formControlName="IndexAsValue" id="IndexAsValue">
+            <select formControlName="IndexAsValue" id="IndexAsValue" [ngModel]="influxmeasForm.value.IndexAsValue">
               <option value="false">false</option>
               <option value="true">true</option>
             </select>
@@ -154,7 +155,7 @@
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement Group"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="influxmeasForm.value.Description"> </textarea>
           <control-messages [control]="influxmeasForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -166,140 +167,4 @@
       </div>
     </form>
   </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="influxmeasForm" class="form-horizontal" (ngSubmit)="updateInfluxMeas()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">ID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of measurement"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" [ngModel]="influxmeasForm.value.ID" />
-          <control-messages [control]="influxmeasForm.controls.ID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Name">Name</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Measurement name used on InfluxDB server"></i>
-        <div class="col-sm-9">
-          <input formControlName="Name" id="Name" [ngModel]="influxmeasForm.value.Name" />
-          <control-messages [control]="influxmeasForm.controls.Name"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="GetMode">GetMode</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Different mode to get the values. On 'value' the measurement collects many values as fields have. On 'indexed' the measurement collects many values as many fields finds on the indexOID request"></i>
-        <div class="col-sm-9">
-          <select formControlName="GetMode" id="GetMode" [ngModel]="influxmeasForm.value.GetMode" (click)="setDynamicFields(influxmeasForm.value.GetMode)">
-            <option value="value">(snmp scalar) Direct Value</option>
-            <option value="indexed">(snmp Table) Indexed with direct TAG</option>
-            <option value="indexed_it">(snmp Table) Indexed with indirect TAG </option>
-          </select>
-          <!--input formControlName="SnmpVersion" id="SnmpVersion" /-->
-          <control-messages [control]="influxmeasForm.controls.GetMode"></control-messages>
-        </div>
-      </div>
-
-        <div class="form-group" *ngIf="influxmeasForm.controls.IndexOID">
-          <label class="control-label col-sm-2" for="IndexOID">IndexOID</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The index OID to get the all real OID's to query data"></i>
-          <div class="col-sm-9">
-            <input formControlName="IndexOID" id="IndexOID" [ngModel]="influxmeasForm.value.IndexOID" />
-            <control-messages [control]="influxmeasForm.controls.IndexOID"></control-messages>
-          </div>
-        </div>
-
-        <div *ngIf="influxmeasForm.controls.TagOID">
-          <div class="form-group">
-            <label class="control-label col-sm-2" for="TagOID">TagOID</label>
-            <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
-            <div class="col-sm-9">
-              <input formControlName="TagOID" id="TagOID" [ngModel]="influxmeasForm.value.TagOID" />
-              <control-messages [control]="influxmeasForm.controls.TagOID"></control-messages>
-            </div>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="influxmeasForm.controls.IndexTag">
-          <label class="control-label col-sm-2" for="IndexTag">IndexTag</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag name that will be sent after data gathered"></i>
-          <div class="col-sm-9">
-            <input formControlName="IndexTag" id="IndexTag" [ngModel]="influxmeasForm.value.IndexTag" />
-            <control-messages [control]="influxmeasForm.controls.IndexTag"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="influxmeasForm.controls.IndexTagFormat">
-          <label class="control-label col-sm-2" for="IndexTag">IndexTagFormat</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag value will be sent parametrized with $IDX1 , $VAL1 (default $VAL1 on direct indexed) and $IDX2, $VAL2 (default $VAL2 on indirect indexed) "></i>
-          <div class="col-sm-9">
-            <input formControlName="IndexTagFormat" id="IndexTagFormat" [ngModel]="influxmeasForm.value.IndexTagFormat" />
-            <control-messages [control]="influxmeasForm.controls.IndexTagFormat"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="influxmeasForm.controls.IndexAsValue">
-          <label class="control-label col-sm-2" for="IndexAsValue">IndexAsValue</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="If set to true the value for the TAG will be the indexnum , else will be the value , remember in SNMP Indexed Tables we will get data on this form snmpget(IndexOID.Indexnum) = value "></i>
-          <div class="col-sm-9">
-            <select formControlName="IndexAsValue" id="IndexAsValue" [ngModel]="influxmeasForm.value.IndexAsValue">
-              <option value="false">false</option>
-              <option value="true">true</option>
-            </select>
-            <control-messages [control]="influxmeasForm.controls.IndexAsValue"></control-messages>
-          </div>
-        </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Fields">Fields</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
-        <div class="col-sm-9">
-          <div>
-            <ss-multiselect-dropdown [options]="selectmetrics" [texts]="myTexts" [settings]="mySettings" [(ngModel)]="selectedMetrics" [ngModelOptions]="{standalone: true}" (ngModelChange)="onChangeMetricArray($event)"></ss-multiselect-dropdown>
-            <control-messages [control]="influxmeasForm.controls.Fields"></control-messages>
-          </div>
-        </div>
-      </div>
-      <div class="form-group" *ngIf="metricArray.length > 0">
-        <label class="control-label col-sm-2" for="Report">Report Fields</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
-        <div class="col-sm-9">
-          <div class="input-group list-group">
-            <div *ngFor="let metric of metricArray; let i = index">
-              <div class="input-group" style="background: none">
-                <div dropdown class="input-group-addon">
-                  <h5 [ngClass]="[reportMetricStatus[metric.Report].icon, reportMetricStatus[metric.Report].class]" role="button" tooltip="{{reportMetricStatus[metric.Report].name}}" class="dropdown-toggle-split" type="button" dropdownToggle></h5>
-                  <ul class="dropdown-menu" dropdownMenu role="menu" aria-labelledby="split-button">
-                    <li role="menuitem" *ngFor="let reportArray of reportMetricStatus; let reportIndex = index">
-                      <span role="button" (click)="onCheckMetric(i,reportIndex)" role="button" class="dropdown-item" [ngClass]="reportArray.class"><i style="padding-left: 5px; margin-right: 5px" [ngClass]="reportArray.icon"></i>{{reportArray.name}}</span>
-                    </li>
-                  </ul>
-                </div>
-                <div class="input-group-addon" style="background: none">
-                  <span [ngClass]="[reportMetricStatus[metric.Report].class]">{{metric.ID}}</span>
-                </div>
-              </div>
-
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement Group"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='influxmeasForm.value.Description'> </textarea>
-          <control-messages [control]="influxmeasForm.controls.Description"></control-messages>
-        </div>
-      </div>
-
-      <div class="col-sm-offset-4 col-sm-6">
-        <button type="submit" [disabled]="!influxmeasForm.valid">Submit</button>
-        <button type="reset" [disabled]="!influxmeasForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-    </form>
-  </template>
-</p>
+</ng-container>

--- a/src/influxserver/influxservereditor.html
+++ b/src/influxserver/influxservereditor.html
@@ -1,7 +1,7 @@
 <h2>Influx Servers</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='InfluxDB Servers'></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this InfluxDB Server will affect the following components','Deleting this InfluxDB Server will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -32,14 +32,13 @@
     </pagination>
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
-  <template ngSwitchCase="create">
-    <form [formGroup]="influxserverForm" class="form-horizontal" (ngSubmit)="saveInfluxServer()">
-
+  <template ngSwitchDefault>
+    <form [formGroup]="influxserverForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveInfluxServer() : updateInfluxServer()">
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of InfluxDB server"></i>
         <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
+          <input formControlName="ID" id="ID" [ngModel]="influxserverForm.value.ID"/>
           <control-messages [control]="influxserverForm.controls.ID"></control-messages>
         </div>
       </div>
@@ -48,7 +47,7 @@
         <label class="control-label col-sm-2" for="Host">Host</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Address of InfluxServer"></i>
         <div class="col-sm-9">
-          <input formControlName="Host" id="Host" placeholder="127.0.0.1 or localhost" />
+          <input formControlName="Host" id="Host" placeholder="127.0.0.1 or localhost" [ngModel]="influxserverForm.value.Host" />
           <control-messages [control]="influxserverForm.controls.Host"></control-messages>
         </div>
       </div>
@@ -57,7 +56,7 @@
         <label class="control-label col-sm-2" for="Port">Port</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Connection port to InfluxDB server {{influxserverForm.value.Host}}"></i>
         <div class="col-sm-9">
-          <input formControlName="Port" id="Port" />
+          <input formControlName="Port" id="Port" [ngModel]="influxserverForm.value.Port"/>
           <control-messages [control]="influxserverForm.controls.Port"></control-messages>
         </div>
       </div>
@@ -66,7 +65,7 @@
         <label class="control-label col-sm-2" for="DB">DB</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="InfluxDB Database name"></i>
         <div class="col-sm-9">
-          <input formControlName="DB" id="DB" />
+          <input formControlName="DB" id="DB" [ngModel]="influxserverForm.value.DB"/>
           <control-messages [control]="influxserverForm.controls.DB"></control-messages>
         </div>
       </div>
@@ -75,7 +74,7 @@
         <label class="control-label col-sm-2" for="User">User</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification user to the DB"></i>
         <div class="col-sm-9">
-          <input formControlName="User" id="User" />
+          <input formControlName="User" id="User"  [ngModel]="influxserverForm.value.User"/>
           <control-messages [control]="influxserverForm.controls.User"></control-messages>
         </div>
       </div>
@@ -84,137 +83,12 @@
         <label class="control-label col-sm-2" for="Password">Password</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification password to the DB of the user {{influxserverForm.value.User}}"></i>
         <div class="col-sm-9">
-          <input #inputPassword formControlName="Password" id="Password" type="password"  />
+          <input #inputPassword formControlName="Password" id="Password" type="password"  [ngModel]="influxserverForm.value.Password"/>
           <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputPassword.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputPassword"> </i>
           <control-messages [control]="influxserverForm.controls.Password"></control-messages>
         </div>
       </div>
 
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Retention">Retention Policy</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retention policy name to write on. RP must exist on the DB {{influxserverForm.value.DB}}"></i>
-        <div class="col-sm-9">
-          <input formControlName="Retention" id="Retention" />
-          <control-messages [control]="influxserverForm.controls.Retention"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Precision">Timestamp Precision</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Sets the precision for the supplied Unix time values (valid values are [ns,u,ms,s,m,h] ). SNMP are a slow gather protocol so default snmpcollector precision are in seconds"></i>
-        <div class="col-sm-9">
-          <select formControlName="Precision" id="Precision">
-            <option value="h">h (hour)</option>
-            <option value="m">m (minute)</option>
-            <option default value="s">s (second)</option>
-            <option value="ms">ms (millisecond)</option>
-            <option value="u">u (microsecond)</option>
-            <option value="ns">ns (nanosecond)</option>
-          </select>
-          <control-messages [control]="influxserverForm.controls.Precision"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Timeout">Timeout</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Time in second that client will wait to a complete write transaction to be complete"></i>
-        <div class="col-sm-9">
-          <input formControlName="Timeout" id="Timeout" />
-          <control-messages [control]="influxserverForm.controls.Timeout"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="UserAgent">User Agent</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="UserAgent is the http User Agent, defaults to &quot;InfluxDBClient&quot; (useful for debugin data write in the server site)"></i>
-        <div class="col-sm-9">
-          <input formControlName="UserAgent" id="UserAgent" />
-          <control-messages [control]="influxserverForm.controls.UserAgent"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the InfluxDB Server"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
-          <control-messages [control]="influxserverForm.controls.Description"></control-messages>
-        </div>
-      </div>
-      <div class="col-sm-2">
-        <button type="button"(click)="testInfluxServerConnection()">Test Connection</button>
-      </div>
-      <div class="col-sm-offset-4 col-sm-5">
-        <button type="submit" [disabled]="!influxserverForm.valid">Submit</button>
-        <button type="reset" [disabled]="!influxserverForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-      <div *ngIf="alertHandler" class="col-md-4">
-        <div [ngClass]="['panel-body', 'bg-'+alertHandler.type,'text-'+alertHandler.type]">
-           <span>{{alertHandler.result}} - Ping elapsed: {{alertHandler.elapsed / 1000000 }} ms</span>
-           <p>{{alertHandler.msg}}</p>
-        </div>
-      </div>
-    </form>
-  </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="influxserverForm" class="form-horizontal" (ngSubmit)="updateInfluxServer()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">id</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of InfluxDB server"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" [ngModel]="influxserverForm.value.ID" />
-          <control-messages [control]="influxserverForm.controls.ID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Host">Host</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Address of InfluxServer"></i>
-        <div class="col-sm-9">
-          <input formControlName="Host" id="Host" [ngModel]="influxserverForm.value.Host" />
-          <control-messages [control]="influxserverForm.controls.Host"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Port">Port</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Connection port to InfluxDB server {{influxserverForm.value.Host}}"></i>
-        <div class="col-sm-9">
-          <input formControlName="Port" id="Port" [ngModel]="influxserverForm.value.Port" />
-          <control-messages [control]="influxserverForm.controls.Port"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="DB">DB</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="InfluxDB Database name"></i>
-        <div class="col-sm-9">
-          <input formControlName="DB" id="DB" [ngModel]="influxserverForm.value.DB" />
-          <control-messages [control]="influxserverForm.controls.DB"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="User">User</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification user to the DB"></i>
-        <div class="col-sm-9">
-          <input formControlName="User" id="User" [ngModel]="influxserverForm.value.User" />
-          <control-messages [control]="influxserverForm.controls.User"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Password">Password</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification password to the DB of the user {{influxserverForm.value.User}}"></i>
-        <div class="col-sm-9">
-          <input #inputPassword formControlName="Password" id="Password" type="password" [ngModel]="influxserverForm.value.Password" />
-          <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputPassword.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputPassword"> </i>
-          <control-messages [control]="influxserverForm.controls.Password"></control-messages>
-        </div>
-      </div>
 
       <div class="form-group">
         <label class="control-label col-sm-2" for="Retention">Retention Policy</label>
@@ -245,7 +119,7 @@
         <label class="control-label col-sm-2" for="Timeout">Timeout</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Time in second that client will wait to a complete write transaction to be complete"></i>
         <div class="col-sm-9">
-          <input formControlName="Timeout" id="Timeout" [ngModel]="influxserverForm.value.Timeout" />
+          <input formControlName="Timeout" id="Timeout" [ngModel]="influxserverForm.value.Timeout"/>
           <control-messages [control]="influxserverForm.controls.Timeout"></control-messages>
         </div>
       </div>
@@ -254,7 +128,7 @@
         <label class="control-label col-sm-2" for="UserAgent">User Agent</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="UserAgent is the http User Agent, defaults to &quot;InfluxDBClient&quot; (useful for debugin data write in the server site)"></i>
         <div class="col-sm-9">
-          <input formControlName="UserAgent" id="UserAgent" [ngModel]="influxserverForm.value.UserAgent" />
+          <input formControlName="UserAgent" id="UserAgent" [ngModel]="influxserverForm.value.UserAgent"/>
           <control-messages [control]="influxserverForm.controls.UserAgent"></control-messages>
         </div>
       </div>
@@ -263,7 +137,7 @@
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the InfluxDB Server"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='influxserverForm.value.Description'> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="influxserverForm.value.Description"> </textarea>
           <control-messages [control]="influxserverForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -283,4 +157,4 @@
       </div>
     </form>
   </template>
-</p>
+</ng-container>

--- a/src/measfilter/measfiltereditor.html
+++ b/src/measfilter/measfiltereditor.html
@@ -1,7 +1,7 @@
 <h2>Measurement Filters</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
 	<template ngSwitchCase="list">
 		<test-modal #viewModal titleName='Measurement Filters'></test-modal>
 		<test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this Measurement Filter will affect the following components','Deleting this Measurement Filter will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -33,13 +33,13 @@
 		<pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
 	</template>
 
-	<template ngSwitchCase="create">
-		<form [formGroup]="measfilterForm" class="form-horizontal" (ngSubmit)="saveMeasFilter()">
+	<template ngSwitchDefault>
+		<form [formGroup]="measfilterForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveMeasFilter() : updateMeasFilter()">
 			<div class="form-group">
 				<label class="control-label col-sm-2" for="ID">ID</label>
 				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of Measurement Filters "></i>
 				<div class="col-sm-9">
-					<input formControlName="ID" id="ID" />
+					<input formControlName="ID" id="ID" [ngModel]="measfilterForm.value.ID"/>
 					<control-messages [control]="measfilterForm.controls.ID"></control-messages>
 				</div>
 			</div>
@@ -48,7 +48,7 @@
 				<label class="control-label col-sm-2" for="IDMeasurementCfg">Measurements</label>
 				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of Measurements to attach the filter"></i>
 				<div class="col-sm-9">
-					  <ss-multiselect-dropdown [options]="selectmeas" formControlName="IDMeasurementCfg" [texts]="myTexts" [settings]="mySettings"></ss-multiselect-dropdown>
+					  <ss-multiselect-dropdown [options]="selectmeas" formControlName="IDMeasurementCfg" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.IDMeasurementCfg"></ss-multiselect-dropdown>
 					<control-messages [control]="measfilterForm.controls.IDMeasurementCfg"></control-messages>
 				</div>
 			</div>
@@ -57,7 +57,7 @@
 				<label class="control-label col-sm-2" for="FType">Filter type</label>
 				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Filter input source: file or condiction OID"></i>
 				<div class="col-sm-9">
-					<select formControlName="FType" id="FType" (click)="setDynamicFields(measfilterForm.value.FType, true)">
+					<select formControlName="FType" id="FType" (click)="setDynamicFields(measfilterForm.value.FType, true)" [ngModel]="measfilterForm.value.FType">
 						<option value="file">File</option>
 						<option value="OIDCondition">OID Condition</option>
 						<option value="CustomFilter" >Custom Filter</option>
@@ -71,19 +71,8 @@
 					<label class="control-label col-sm-2" for="FilterName">File Name</label>
 					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="A valid filename cointained in the conf/ directory"></i>
 					<div class="col-sm-9">
-						<input formControlName="FilterName" id="FilterName" />
+						<input formControlName="FilterName" id="FilterName" [ngModel]="measfilterForm.value.FilterName"/>
 						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
-					</div>
-				</div>
-				<div class="form-group" *ngIf="measfilterForm.controls.EnableAlias">
-					<label class="control-label col-sm-2" for="EnableAlias">Enable alias</label>
-					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Allow get measurement tag from alias in the file"></i>
-					<div class="col-sm-9">
-						<select formControlName="EnableAlias" id="EnableAlias">
-							<option value="true">Enable</option>
-							<option value="false">Disable</option>
-						</select>
-						<control-messages [control]="measfilterForm.controls.EnableAlias"></control-messages>
 					</div>
 				</div>
 			</div>
@@ -93,7 +82,7 @@
 					<label class="control-label col-sm-2" for="FilterName">Oid Condition</label>
 					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="valid OID condition in the OID conditions table"></i>
 					<div class="col-sm-9">
-						<ss-multiselect-dropdown [options]="selectoidcond" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings"></ss-multiselect-dropdown>
+						<ss-multiselect-dropdown [options]="selectoidcond" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.FilterName"></ss-multiselect-dropdown>
 						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
 					</div>
 				</div>
@@ -104,101 +93,10 @@
 					<label class="control-label col-sm-2" for="FilterName">Custom Filter</label>
 					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Valid Custom FIlter on the Custom Filter Table"></i>
 					<div class="col-sm-9">
-						<ss-multiselect-dropdown [options]="selectCustomFilters" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings" ></ss-multiselect-dropdown>
+						<ss-multiselect-dropdown [options]="selectCustomFilters" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.FilterName" ></ss-multiselect-dropdown>
 						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
 					</div>
 				</div>
-				<div class="form-group" *ngIf="measfilterForm.controls.EnableAlias">
-					<label class="control-label col-sm-2" for="EnableAlias">Enable alias</label>
-					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Allow get measurement tag from alias in the file"></i>
-					<div class="col-sm-9">
-						<select formControlName="EnableAlias" id="EnableAlias">
-							<option value="true">Enable</option>
-							<option value="false">Disable</option>
-						</select>
-						<control-messages [control]="measfilterForm.controls.EnableAlias"></control-messages>
-					</div>
-				</div>
-
-			<div class="form-group">
-				<label class="control-label col-sm-2" for="Description">Description</label>
-				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Device"></i>
-				<div class="col-sm-9">
-					<textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
-					<control-messages [control]="measfilterForm.controls.Description"></control-messages>
-				</div>
-			</div>
-
-			<div class="col-sm-offset-4 col-sm-6">
-				<button type="submit" [disabled]="!measfilterForm.valid">Submit</button>
-				<button type="reset" [disabled]="!measfilterForm.dirty">Reset</button>
-				<button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-			</div>
-
-		</form>
-
-	</template>
-
-	<template ngSwitchCase="modify">
-		<form [formGroup]="measfilterForm" class="form-horizontal" (ngSubmit)="updateMeasFilter()">
-			<div class="form-group">
-				<label class="control-label col-sm-2" for="ID">ID</label>
-				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of Measurement Filters "></i>
-				<div class="col-sm-9">
-					<input formControlName="ID" id="ID" [ngModel]="measfilterForm.value.ID" />
-					<control-messages [control]="measfilterForm.controls.ID"></control-messages>
-				</div>
-			</div>
-
-			<div class="form-group">
-				<label class="control-label col-sm-2" for="IDMeasurementCfg">Measurements</label>
-				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of Measurements to attach the filter"></i>
-				<div class="col-sm-9">
-					<ss-multiselect-dropdown [options]="selectmeas" formControlName="IDMeasurementCfg" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.IDMeasurementCfg"></ss-multiselect-dropdown>					<control-messages [control]="measfilterForm.controls.IDMeasurementCfg"></control-messages>
-				</div>
-			</div>
-			<div class="form-group">
-				<label class="control-label col-sm-2" for="FType">Filter type</label>"
-				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Filter input source: file or condiction OID"></i>
-				<div class="col-sm-9">
-					<select formControlName="FType" id="FType" [ngModel]="measfilterForm.value.FType" (click)="setDynamicFields(measfilterForm.value.FType, true)">
-						<option value="file">File</option>
-						<option value="OIDCondition">OID Condition</option>
-						<option value="CustomFilter" >Custom Filter</option>
-					</select>
-					<control-messages [control]="measfilterForm.controls.FType"></control-messages>
-				</div>
-			</div>
-
-				<div class="form-group" *ngIf="measfilterForm.value.FType == 'file'">
-					<label class="control-label col-sm-2" for="FilterName">File Name</label>
-					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="A valid filename cointained in the conf/ directory"></i>
-					<div class="col-sm-9">
-						<input formControlName="FilterName" id="FilterName" [ngModel]="measfilterForm.value.FilterName" />
-						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
-					</div>
-				</div>
-
-			<div *ngIf="measfilterForm.value.FType == 'OIDCondition'">
-        <div class="form-group">
-					<label class="control-label col-sm-2" for="FilterName">OID Condition</label>
-					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="valid OID condition in the OID conditions table"></i>
-					<div class="col-sm-9">
-						<ss-multiselect-dropdown [options]="selectoidcond" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.FilterName"></ss-multiselect-dropdown>
-						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
-					</div>
-				</div>
-			</div>
-
-        <div class="form-group" *ngIf="measfilterForm.value.FType == 'CustomFilter'">
-					<label class="control-label col-sm-2" for="FilterName">Custom Filter</label>
-					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Valid Custom FIlter on the Custom Filter Table"></i>
-					<div class="col-sm-9">
-						<ss-multiselect-dropdown [options]="selectCustomFilters" formControlName="FilterName" [texts]="myTexts" [settings]="mySettings" [ngModel]="measfilterForm.value.FilterName"></ss-multiselect-dropdown>
-						<control-messages [control]="measfilterForm.controls.FilterName"></control-messages>
-					</div>
-				</div>
-
 				<div class="form-group" *ngIf="measfilterForm.controls.EnableAlias">
 					<label class="control-label col-sm-2" for="EnableAlias">Enable alias</label>
 					<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Allow get measurement tag from alias in the file"></i>
@@ -213,7 +111,7 @@
 
 			<div class="form-group">
 				<label class="control-label col-sm-2" for="Description">Description</label>
-				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement Filter"></i>
+				<i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Device"></i>
 				<div class="col-sm-9">
 					<textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="measfilterForm.value.Description"> </textarea>
 					<control-messages [control]="measfilterForm.controls.Description"></control-messages>
@@ -225,6 +123,8 @@
 				<button type="reset" [disabled]="!measfilterForm.dirty">Reset</button>
 				<button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
 			</div>
+
 		</form>
+
 	</template>
-</p>
+</ng-container>

--- a/src/measgroup/measgroupeditor.html
+++ b/src/measgroup/measgroupeditor.html
@@ -1,7 +1,7 @@
 <h2>Measurement Groups</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='Measurements Groups'></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this Measurement Group will affect the following components','Deleting this Measurement Group will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -33,13 +33,13 @@
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
 
-  <template ngSwitchCase="create">
-    <form [formGroup]="measgroupForm" class="form-horizontal" (ngSubmit)="saveMeasGroup()">
+  <template ngSwitchDefault>
+    <form [formGroup]="measgroupForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveMeasGroup() : updateMeasGroup()">
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of Measurement Group"></i>
         <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
+          <input formControlName="ID" id="ID" [ngModel]="measgroupForm.value.ID"/>
           <control-messages [control]="measgroupForm.controls.ID"></control-messages>
         </div>
       </div>
@@ -48,7 +48,7 @@
         <label class="control-label col-sm-2" for="Measurements">Measurements</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of measurements ready to be attached on {{measgroupForm.controls.ID.value}}"></i>
         <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectmeas" formControlName="Measurements" [texts]="myTexts" [settings]="mySettings"></ss-multiselect-dropdown>
+          <ss-multiselect-dropdown [options]="selectmeas" formControlName="Measurements" [texts]="myTexts" [settings]="mySettings" [ngModel]="measgroupForm.value.Measurements"></ss-multiselect-dropdown>
           <control-messages [control]="measgroupForm.controls.Measurements"></control-messages>
         </div>
       </div>
@@ -57,7 +57,7 @@
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Device"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="measgroupForm.value.Description"> </textarea>
           <control-messages [control]="measgroupForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -69,41 +69,4 @@
       </div>
     </form>
   </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="measgroupForm" class="form-horizontal" (ngSubmit)="updateMeasGroup()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">ID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Connection port to the Device by SNMP protocol"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" [ngModel]="measgroupForm.value.ID" />
-          <control-messages [control]="measgroupForm.controls.ID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Measurements">Measurements</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Connection port to the Device by SNMP protocol"></i>
-        <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectmeas" formControlName="Measurements" [texts]="myTexts" [settings]="mySettings" [ngModel]="measgroupForm.value.Measurements"></ss-multiselect-dropdown>
-          <control-messages [control]="measgroupForm.controls.Measurements"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement Group"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='measgroupForm.value.Description'> </textarea>
-          <control-messages [control]="measgroupForm.controls.Description"></control-messages>
-        </div>
-      </div>
-
-      <div class="col-sm-offset-4 col-sm-6">
-        <button type="submit" [disabled]="!measgroupForm.valid">Submit</button>
-        <button type="reset" [disabled]="!measgroupForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-    </form>
-  </template>
-</p>
+</ng-container>

--- a/src/oidcondition/oidconditioneditor.html
+++ b/src/oidcondition/oidconditioneditor.html
@@ -1,7 +1,7 @@
 <h2>OID Conditions</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='OID Conditions'></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this OID Condition will affect the following components','Deleting this OID Condition will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -33,13 +33,13 @@
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
 
-  <template ngSwitchCase="create">
-    <form [formGroup]="oidconditionForm" class="form-horizontal" (ngSubmit)="saveOidCondition()">
+  <template ngSwitchDefault>
+    <form [formGroup]="oidconditionForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveOidCondition() : updateOidCondition()">
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique metric identifier"></i>
         <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
+          <input formControlName="ID" id="ID" [ngModel]="oidconditionForm.value.ID"/>
           <control-messages [control]="oidconditionForm.controls.ID"></control-messages>
         </div>
       </div>
@@ -48,7 +48,7 @@
         <label class="control-label col-sm-2" for="IsMultiple">Is Multiple</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of Condition query"></i>
         <div class="col-sm-9">
-          <select formControlName="IsMultiple" id="IsMutiple" (click)="setDynamicFields(oidconditionForm.value.IsMultiple, true)">
+          <select formControlName="IsMultiple" id="IsMutiple" (click)="setDynamicFields(oidconditionForm.value.IsMultiple, true)" [ngModel]="oidconditionForm.value.IsMultiple">
             <option value="true">(true) This Condition is defined as boolean expresion from other OID conditions</option>
             <option value="false">(false) This condition is defined from an OID --default-- </option>
           </select>
@@ -60,92 +60,12 @@
         <label class="control-label col-sm-2" for="OIDCond">{{(oidconditionForm.value.IsMultiple === "true" || oidconditionForm.value.IsMultiple === true) ? 'OID Condition' : 'OID'}}</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of Condition query"></i>
         <div class="col-sm-9">
-          <input formControlName="OIDCond" id="OIDCond" />
+          <input formControlName="OIDCond" id="OIDCond" [ngModel]="oidconditionForm.value.OIDCond" />
           <control-messages [control]="oidconditionForm.controls.OIDCond"></control-messages>
         </div>
       </div>
       <div *ngIf="oidconditionForm.controls.CondType">
         <div class="form-group">
-          <label class="control-label col-sm-2" for="CondType">CondType</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
-          <div class="col-sm-9">
-            <select formControlName="CondType" id="CondType">
-              <option value="match">(match) string regexp match</option>
-              <option value="notmatch">(notmatch) string regex match inverse</option>
-              <option value="neq">(neq) numeric equal</option>
-              <option value="ndif">(ndif) numeric different (not equal)</option>
-              <option value="nlt">(nlt) numeric less than</option>
-              <option value="ngt">(ngt) numeric Greater than</option>
-              <option value="nge">(nge) numeric Greater or Equal</option>
-              <option value="nle">(nle) numeric less or equal </option>
-            </select>
-            <control-messages [control]="oidconditionForm.controls.CondType"></control-messages>
-          </div>
-        </div>
-
-
-        <div class="form-group" *ngIf="oidconditionForm.controls.CondValue">
-          <label class="control-label col-sm-2" for="CondValue">CondValue</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Extra data for the measurement"></i>
-          <div class="col-sm-9">
-            <input formControlName="CondValue" id="CondValue" />
-            <control-messages [control]="oidconditionForm.controls.CondValue"></control-messages>
-          </div>
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the OID Condition"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
-          <control-messages [control]="oidconditionForm.controls.Description"></control-messages>
-        </div>
-      </div>
-
-      <div class="col-sm-offset-4 col-sm-6">
-        <button type="submit" [disabled]="!oidconditionForm.valid">Submit</button>
-        <button type="reset" [disabled]="!oidconditionForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-    </form>
-
-  </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="oidconditionForm" class="form-horizontal" (ngSubmit)="updateOidCondition()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">ID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique metric identifier"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" [ngModel]="oidconditionForm.value.ID" />
-          <control-messages [control]="oidconditionForm.controls.ID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="IsMultiple">Is Multiple</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of Condition query"></i>
-        <div class="col-sm-9">
-          <select formControlName="IsMultiple" id="IsMutiple" [ngModel]="oidconditionForm.value.IsMultiple" (click)="setDynamicFields(oidconditionForm.value.IsMultiple, true)">
-            <option value="true">(true) This Condition is defined as boolean expresion from other OID conditions</option>
-            <option value="false">(false) This condition is defined from an OID --default-- </option>
-          </select>
-          <control-messages [control]="oidconditionForm.controls.IsMultiple"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="OIDCond">{{(oidconditionForm.value.IsMultiple === "true" || oidconditionForm.value.IsMultiple === true) ? 'OID Condition' : 'OID'}} </label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of SNMP query"></i>
-        <div class="col-sm-9">
-          <input formControlName="OIDCond" id="OIDCond" [ngModel]="oidconditionForm.value.OIDCond" />
-          <control-messages [control]="oidconditionForm.controls.OIDCond"></control-messages>
-        </div>
-      </div>
-
-        <div class="form-group" *ngIf="oidconditionForm.controls.CondType">
           <label class="control-label col-sm-2" for="CondType">CondType</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
           <div class="col-sm-9">
@@ -163,20 +83,23 @@
           </div>
         </div>
 
+
         <div class="form-group" *ngIf="oidconditionForm.controls.CondValue">
           <label class="control-label col-sm-2" for="CondValue">CondValue</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Extra data for the measurement"></i>
           <div class="col-sm-9">
-            <input formControlName="CondValue" id="CondValue" [ngModel]='oidconditionForm.value.CondValue'/>
+            <input formControlName="CondValue" id="CondValue" [ngModel]="oidconditionForm.value.CondValue"/>
             <control-messages [control]="oidconditionForm.controls.CondValue"></control-messages>
           </div>
         </div>
+
+      </div>
 
       <div class="form-group">
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the OID Condition"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='oidconditionForm.value.Description'> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="oidconditionForm.value.Description"> </textarea>
           <control-messages [control]="oidconditionForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -187,5 +110,6 @@
         <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
       </div>
     </form>
+
   </template>
-</p>
+</ng-container>

--- a/src/runtime/runtime.component.ts
+++ b/src/runtime/runtime.component.ts
@@ -554,7 +554,7 @@ export class RuntimeComponent implements OnDestroy {
       this.noConnectedFilter = true;
       this.activeFilter = false;
       this.deactiveFilter = false;
-      this.data = this.runtime_devs.filter((item) => { if(item.DeviceConnected === false) return true })
+      this.data = this.runtime_devs.filter((item) => { if(item.DeviceConnected === false && item.DeviceActive === true) return true })
     } else {
       this.data = this.runtime_devs;
       this.noConnectedFilter = false;

--- a/src/snmpdevice/snmpdevicecfg.component.ts
+++ b/src/snmpdevice/snmpdevicecfg.component.ts
@@ -137,7 +137,6 @@ export class SnmpDeviceCfgComponent {
       Active: [this.snmpdevForm ? this.snmpdevForm.value.Active : 'true', Validators.required],
       SnmpVersion: [this.snmpdevForm ? this.snmpdevForm.value.SnmpVersion : '2c', Validators.required],
       DisableBulk: [this.snmpdevForm ? this.snmpdevForm.value.DisableBulk : 'false'],
-      Community: [this.snmpdevForm ? this.snmpdevForm.value.Community : 'public'],
       MaxRepetitions: [this.snmpdevForm ? this.snmpdevForm.value.MaxRepetitions : 50, Validators.compose([Validators.required,ValidationService.uinteger8NotZeroValidator])],
       Freq: [this.snmpdevForm ? this.snmpdevForm.value.Freq : 60, Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator])],
       UpdateFltFreq: [this.snmpdevForm ? this.snmpdevForm.value.UpdateFltFreq : 60, Validators.compose([Validators.required, ValidationService.uintegerAndLessOneValidator])],
@@ -244,8 +243,6 @@ export class SnmpDeviceCfgComponent {
   }
 
   applyAction(test : any) : void {
-    //test.devices = [];
-    //test.devices = this.selectedArray.map((item) => {return item.ID});
     switch(test.action) {
        case "RemoveAllSelected": {
           this.removeAllSelectedItems(this.selectedArray);
@@ -412,11 +409,10 @@ export class SnmpDeviceCfgComponent {
     } else {
       this.setDynamicFields(null);
     }
-
-    this.editmode = "create";
     this.getInfluxServersforDevices();
     this.getMeasGroupsforDevices();
     this.getMeasFiltersforDevices();
+    this.editmode = "create";
   }
 
   editDevice(row) {

--- a/src/snmpdevice/snmpdeviceeditor.html
+++ b/src/snmpdevice/snmpdeviceeditor.html
@@ -1,7 +1,7 @@
 <h2>SNMP Devices</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='Device'></test-modal>
     <export-file-modal #exportFileModal [showValidation]="true" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
@@ -33,350 +33,8 @@
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
 
-  <template ngSwitchCase="create">
-    <form [formGroup]="snmpdevForm" class="form-horizontal" (ngSubmit)="saveSnmpDev()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">ID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of SNMP Device"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
-          <control-messages [control]="snmpdevForm.controls.ID"></control-messages>
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="host">Host</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Host (IP or FQDN) of SNMP device to connnect by SNMP protocol"></i>
-        <div class="col-sm-9">
-          <input formControlName="Host" id="Host" />
-          <control-messages [control]="snmpdevForm.controls.Host"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Port">Port</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Connection port to the device using SNMP protocol"></i>
-        <div class="col-sm-9">
-          <input formControlName="Port" id="Port" />
-          <control-messages [control]="snmpdevForm.controls.Port"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Timeout">Timeout</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Timeout for the SNMP Query"></i>
-        <div class="col-sm-9">
-          <input formControlName="Timeout" id="Timeout" />
-          <control-messages [control]="snmpdevForm.controls.Timeout"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Retries">Retries</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set the number of retries to attempt within timeout"></i>
-        <div class="col-sm-9">
-          <input formControlName="Retries" id="Retries" />
-          <control-messages [control]="snmpdevForm.controls.Retries"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="SystemOIDs">Alternate System OID's</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set OID to get like MIB-2::System Info (NEEDED TO CHECK connectivity to the device!!! for non MIB-2 based devices)"></i>
-        <div class="col-sm-9">
-          <input formControlName="SystemOIDs" id="SystemOIDs" />
-          <control-messages [control]="snmpdevForm.controls.SystemOIDs"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="SnmpDebug">Active</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Active on Collector reboot"></i>
-        <div class="col-sm-9">
-          <select formControlName="Active" id="Active">
-            <option value="true">True</option>
-            <option value="false">False</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.Active"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="SnmpVersion">SnmpVersion</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMP Version (1,2c,3)"></i>
-        <div class="col-sm-9">
-          <select formControlName="SnmpVersion" id="SnmpVersion" (click)="setDynamicFields(snmpdevForm.value.SnmpVersion)">
-            <option value="1">1</option>
-            <option value="2c" selected="selected">2c</option>
-            <option value="3">3</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.SnmpVersion"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '1' ">
-        <label class="control-label col-sm-2" for="DisableBulk">DisableBulk</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Active on Collector reboot"></i>
-        <div class="col-sm-9">
-          <select formControlName="DisableBulk" id="DisableBulk">
-            <option value="true">True</option>
-            <option value="false">False</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.DisableBulk"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '1' ">
-        <label class="control-label col-sm-2" for="MaxRepetitions">MaxRepetitions</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set the MaxRepetitions value for BULKWALK SNMP Queries (valid ranges is 1-255) default 50"></i>
-        <div class="col-sm-9">
-          <input formControlName="MaxRepetitions" id="MaxRepetitions" />
-          <control-messages [control]="snmpdevForm.controls.MaxRepetitions"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '3'">
-        <label class="control-label col-sm-2" for="Community">Community</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Community for authentication"></i>
-        <div class="col-sm-9">
-          <input #Community formControlName="Community" id="Community" type="password" />
-          <i style="margin-left:-25px; margin-right:6px" [ngClass]="Community.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="Community"> </i>
-          <control-messages [control]="snmpdevForm.controls.Community"></control-messages>
-        </div>
-      </div>
-
-      <div *ngIf="snmpdevForm.value.SnmpVersion == 3">
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3SecLevel">
-          <label class="control-label col-sm-2" for="V3SecLevel">V3SecLevel</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification security request mode"></i>
-          <div class="col-sm-9">
-            <select formControlName="V3SecLevel" id="V3SecLevel" (click)="setDynamicFields(snmpdevForm.value.V3SecLevel)">
-              <option value="NoAuthNoPriv">NoAuthNoPriv</option>
-              <option value="AuthNoPriv">AuthNoPriv</option>
-              <option value="AuthPriv">AuthPriv</option>
-            </select>
-            <control-messages [control]="snmpdevForm.controls.V3SecLevel"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3AuthUser">
-          <label class="control-label col-sm-2" for="V3AuthUser">V3AuthUser</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentication user"></i>
-          <div class="col-sm-9">
-            <input formControlName="V3AuthUser" id="V3AuthUser" />
-            <control-messages [control]="snmpdevForm.controls.V3AuthUser"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3AuthPass">
-          <label class="control-label col-sm-2" for="V3AuthPass">V3AuthPass</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentication password"></i>
-          <div class="col-sm-9">
-            <input #inputV3AuthPass formControlName="V3AuthPass" id="V3AuthPass" type="password" />
-            <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputV3AuthPass.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputV3AuthPass"> </i>
-            <control-messages [control]="snmpdevForm.controls.V3AuthPass"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3AuthProt">
-          <label class="control-label col-sm-2" for="V3AuthProt">V3AuthProt</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentication protocol"></i>
-          <div class="col-sm-9">
-            <select formControlName="V3AuthProt" id="V3AuthProt">
-              <option value="MD5">MD5</option>
-              <option value="SHA">SHA</option>
-            </select>
-            <control-messages [control]="snmpdevForm.controls.V3AuthProt"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3PrivPass">
-          <label class="control-label col-sm-2" for="V3PrivPass">V3PrivPass</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Privacy password"></i>
-          <div class="col-sm-9">
-            <input #inputV3PrivPass formControlName="V3PrivPass" id="V3PrivPass" type="password" />
-            <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputV3PrivPass.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputV3PrivPass"> </i>
-            <control-messages [control]="snmpdevForm.controls.V3PrivPass"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3PrivProt">
-          <label class="control-label col-sm-2" for="V3PrivProt">V3PrivProt</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Privacy Protocol"></i>
-          <div class="col-sm-9">
-            <select formControlName="V3PrivProt" id="V3PrivProt">
-              <option value="AES">AES</option>
-              <option value="DES">DES</option>
-            </select>
-            <control-messages [control]="snmpdevForm.controls.V3PrivProt"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3ContextEngineID">
-          <label class="control-label col-sm-2" for="V3ContextEngineID">V3ContextEngineID</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMPV3 ContextEngineID in ScopedPDU (equivalent to the net-snmp -E paramenter)"></i>
-          <div class="col-sm-9">
-            <input formControlName="V3ContextEngineID" id="V3ContextEngineID"   />
-            <control-messages [control]="snmpdevForm.controls.V3ContextEngineID"></control-messages>
-          </div>
-        </div>
-
-        <div class="form-group" *ngIf="snmpdevForm.controls.V3ContextName">
-          <label class="control-label col-sm-2" for="V3ContextName">V3ContextName</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMPV3 ContextName in ScopedPDU ( equivalent to the net-snmp -n parameter)"></i>
-          <div class="col-sm-9">
-            <input formControlName="V3ContextName" id="V3ContextName" />
-            <control-messages [control]="snmpdevForm.controls.V3ContextName"></control-messages>
-          </div>
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Freq">Freq</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Frequency of snmp data polling (in seconds)"></i>
-        <div class="col-sm-9">
-          <input formControlName="Freq" id="Freq" />
-          <control-messages [control]="snmpdevForm.controls.Freq"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="UpdateFltFreq">UpdateFltFreq</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Number of snmp data gather cicles the collector will take to update  indexes and filters on (indexed/snmptable) measurements of snmp data polling (time will be this number*freq seconds) <br> Set this valie to -1 to disable indexes and filters updates "></i>
-        <div class="col-sm-9">
-          <input formControlName="UpdateFltFreq" id="UpdateFltFreq" />
-          <control-messages [control]="snmpdevForm.controls.UpdateFltFreq"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ConcurrentGather">ConcurrentGather</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Open a new snmp connection for each measurement and send concurrent queries over the device "></i>
-        <div class="col-sm-9">
-          <select formControlName="ConcurrentGather" id="ConcurrentGather" >
-            <option value="true">True</option>
-            <option value="false">False</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.ConcurrentGather"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="OutDB">InfluxDB Server</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="InfluxDB server"></i>
-        <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectinfluxservers" formControlName="OutDB" [texts]="myTexts" [settings]="mySettingsInflux"></ss-multiselect-dropdown>
-          <control-messages [control]="snmpdevForm.controls.OutDB"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="LogLevel">Log level</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Severity log level"></i>
-        <div class="col-sm-9">
-          <select formControlName="LogLevel" id="LogLevel">
-            <option value="panic">Panic</option>
-            <option value="fatal">Fatal</option>
-            <option value="error">Error</option>
-            <option value="warn">Warning</option>
-            <option selected="selected" value="info">Info</option>
-            <option value="debug">Debug</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.LogLevel"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="SnmpDebug">SnmpDebug</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Show SNMP debug"></i>
-        <div class="col-sm-9">
-          <select formControlName="SnmpDebug" id="SnmpDebug">
-            <option value="true">True</option>
-            <option value="false">False</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.SnmpDebug"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="DeviceTagName">Device Tag Name</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify type of device in InfluxDB"></i>
-        <div class="col-sm-9">
-          <input formControlName="DeviceTagName" id="DeviceTagName" placeholder="device, host, switch..." />
-          <control-messages [control]="snmpdevForm.controls.DeviceTagName"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="DeviceTagValue">Device Tag Value</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify the device in InfluxDB"></i>
-        <div class="col-sm-9">
-          <select formControlName="DeviceTagValue" id="DeviceTagValue">
-            <option selected="selected" value="id">Id - {{snmpdevForm.controls.ID.value}}</option>
-            <option value="host">Host - {{snmpdevForm.controls.Host.value}}</option>
-          </select>
-          <control-messages [control]="snmpdevForm.controls.DeviceTagValue"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ExtraTags">ExtraTags</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify the device in InfluxDB"></i>
-        <div class="col-sm-9">
-          <input formControlName="ExtraTags" id="ExtraTags" />
-          <control-messages [control]="snmpdevForm.controls.ExtraTags"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="MeasurementGroups">Measurement Groups</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Selection of Measurent Groups associated with the device {{snmpdevForm.value.id}}"></i>
-        <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectgroups" formControlName="MeasurementGroups" [texts]="myTexts" [settings]="mySettings"></ss-multiselect-dropdown>
-          <control-messages [control]="snmpdevForm.controls.MeasurementGroups"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="MeasFilters">Measurement Filters</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Selection of filters to use with the device {{snmpdevForm.value.id}}"></i>
-        <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectfilters" formControlName="MeasFilters" [texts]="myTexts" [settings]="mySettings" ></ss-multiselect-dropdown>
-          <control-messages [control]="snmpdevForm.controls.MeasFilters"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Device"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
-          <control-messages [control]="snmpdevForm.controls.Description"></control-messages>
-        </div>
-      </div>
-
-      <div class="col-sm-2 col-md-offset-1">
-        <button type="button" [disabled]="!snmpdevForm.valid" (click)="showTestConnectionModal()">Test Connection</button>
-      </div>
-      <test-connection-modal #viewTestConnectionModal titleName='Test connection for:'>
-      </test-connection-modal>
-      <test-filter-modal #viewTestFilterModal titleName='Filter connection:' [formValues]="snmpdevForm.value">
-      </test-filter-modal>
-      <div class="col-sm-2">
-        <button type="button" [disabled]="!snmpdevForm.valid" (click)="showFilterModal()">Filter Connection</button>
-      </div>
-
-
-      <div class="col-sm-offset-2 col-sm-3">
-        <button type="submit" [disabled]="!snmpdevForm.valid">Submit</button>
-        <button type="reset" [disabled]="!snmpdevForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-    </form>
-  </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="snmpdevForm" class="form-horizontal" (ngSubmit)="updateSnmpDev()">
+  <template ngSwitchDefault>
+    <form [formGroup]="snmpdevForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveSnmpDev() : updateSnmpDev()">
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of SNMP Device"></i>
@@ -385,10 +43,9 @@
           <control-messages [control]="snmpdevForm.controls.ID"></control-messages>
         </div>
       </div>
-
       <div class="form-group">
         <label class="control-label col-sm-2" for="host">Host</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Host (IP or FQDN) of SNMP device to connnect using SNMP protocol"></i>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Host (IP or FQDN) of SNMP device to connnect by SNMP protocol"></i>
         <div class="col-sm-9">
           <input formControlName="Host" id="Host" [ngModel]="snmpdevForm.value.Host" />
           <control-messages [control]="snmpdevForm.controls.Host"></control-messages>
@@ -426,7 +83,7 @@
         <label class="control-label col-sm-2" for="SystemOIDs">Alternate System OID's</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set OID to get like MIB-2::System Info (NEEDED TO CHECK connectivity to the device!!! for non MIB-2 based devices)"></i>
         <div class="col-sm-9">
-          <input formControlName="SystemOIDs" id="SystemOIDs" [ngModel]="snmpdevForm.value.SystemOIDs"  />
+          <input formControlName="SystemOIDs" id="SystemOIDs" [ngModel]="snmpdevForm.value.SystemOIDs" />
           <control-messages [control]="snmpdevForm.controls.SystemOIDs"></control-messages>
         </div>
       </div>
@@ -447,7 +104,7 @@
         <label class="control-label col-sm-2" for="SnmpVersion">SnmpVersion</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMP Version (1,2c,3)"></i>
         <div class="col-sm-9">
-          <select formControlName="SnmpVersion" id="SnmpVersion" [ngModel]="snmpdevForm.value.SnmpVersion" (click)="setDynamicFields(snmpdevForm.value.SnmpVersion)" >
+          <select formControlName="SnmpVersion" id="SnmpVersion" (click)="setDynamicFields(snmpdevForm.value.SnmpVersion)" [ngModel]="snmpdevForm.value.SnmpVersion">
             <option value="1">1</option>
             <option value="2c" selected="selected">2c</option>
             <option value="3">3</option>
@@ -458,7 +115,7 @@
 
       <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '1' ">
         <label class="control-label col-sm-2" for="DisableBulk">DisableBulk</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Disable Snmp Bulk request on devices with problems"></i>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Active on Collector reboot"></i>
         <div class="col-sm-9">
           <select formControlName="DisableBulk" id="DisableBulk" [ngModel]="snmpdevForm.value.DisableBulk">
             <option value="true">True</option>
@@ -469,19 +126,19 @@
       </div>
 
       <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '1' ">
-        <label class="control-label col-sm-2" for="MaxRepetitions">MaxRepetitions</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set the MaxRepetitions value for BULKWALK SNMP Queries"></i>
+        <label class="control-label col-sm-2" for="MaxRepetitions" >MaxRepetitions</label>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Set the MaxRepetitions value for BULKWALK SNMP Queries (valid ranges is 1-255) default 50"></i>
         <div class="col-sm-9">
-          <input formControlName="MaxRepetitions" id="MaxRepetitions"  [ngModel]="snmpdevForm.value.MaxRepetitions" />
+          <input formControlName="MaxRepetitions" id="MaxRepetitions" [ngModel]="snmpdevForm.value.MaxRepetitions"/>
           <control-messages [control]="snmpdevForm.controls.MaxRepetitions"></control-messages>
         </div>
       </div>
 
-      <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '3'">
+      <div class="form-group" *ngIf="snmpdevForm.value.SnmpVersion != '3' && snmpdevForm.controls.Community">
         <label class="control-label col-sm-2" for="Community">Community</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Community for authentication"></i>
         <div class="col-sm-9">
-          <input #Community formControlName="Community" id="Community" [ngModel]="snmpdevForm.value.Community" type="password" />
+          <input #Community formControlName="Community" id="Community" type="password" [ngModel]="snmpdevForm.value.Community"/>
           <i style="margin-left:-25px; margin-right:6px" [ngClass]="Community.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="Community"> </i>
           <control-messages [control]="snmpdevForm.controls.Community"></control-messages>
         </div>
@@ -492,9 +149,9 @@
           <label class="control-label col-sm-2" for="V3SecLevel">V3SecLevel</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentification security request mode"></i>
           <div class="col-sm-9">
-            <select formControlName="V3SecLevel" id="V3SecLevel" [ngModel]="snmpdevForm.value.V3SecLevel" (click)="setDynamicFields(snmpdevForm.value.V3SecLevel)">
+            <select formControlName="V3SecLevel" id="V3SecLevel" (click)="setDynamicFields(snmpdevForm.value.V3SecLevel)" [ngModel]="snmpdevForm.value.V3SecLevel">
               <option value="NoAuthNoPriv">NoAuthNoPriv</option>
-              <option value="AuthNoPriv" >AuthNoPriv</option>
+              <option value="AuthNoPriv">AuthNoPriv</option>
               <option value="AuthPriv">AuthPriv</option>
             </select>
             <control-messages [control]="snmpdevForm.controls.V3SecLevel"></control-messages>
@@ -505,7 +162,7 @@
           <label class="control-label col-sm-2" for="V3AuthUser">V3AuthUser</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentication user"></i>
           <div class="col-sm-9">
-            <input formControlName="V3AuthUser" id="V3AuthUser" [ngModel]="snmpdevForm.value.V3AuthUser" />
+            <input formControlName="V3AuthUser" id="V3AuthUser" [ngModel]="snmpdevForm.value.V3AuthUser"/>
             <control-messages [control]="snmpdevForm.controls.V3AuthUser"></control-messages>
           </div>
         </div>
@@ -514,7 +171,7 @@
           <label class="control-label col-sm-2" for="V3AuthPass">V3AuthPass</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Authentication password"></i>
           <div class="col-sm-9">
-            <input #inputV3AuthPass formControlName="V3AuthPass" id="V3AuthPass" type="password" [ngModel]="snmpdevForm.value.V3AuthPass" />
+            <input #inputV3AuthPass formControlName="V3AuthPass" id="V3AuthPass" type="password" [ngModel]="snmpdevForm.value.V3AuthPass"/>
             <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputV3AuthPass.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputV3AuthPass"> </i>
             <control-messages [control]="snmpdevForm.controls.V3AuthPass"></control-messages>
           </div>
@@ -536,7 +193,7 @@
           <label class="control-label col-sm-2" for="V3PrivPass">V3PrivPass</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Privacy password"></i>
           <div class="col-sm-9">
-            <input #inputV3PrivPass formControlName="V3PrivPass" id="V3PrivPass" type="password" [ngModel]="snmpdevForm.value.V3PrivPass" />
+            <input #inputV3PrivPass formControlName="V3PrivPass" id="V3PrivPass" type="password" [ngModel]="snmpdevForm.value.V3PrivPass"/>
             <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputV3PrivPass.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputV3PrivPass"> </i>
             <control-messages [control]="snmpdevForm.controls.V3PrivPass"></control-messages>
           </div>
@@ -552,33 +209,31 @@
             </select>
             <control-messages [control]="snmpdevForm.controls.V3PrivProt"></control-messages>
           </div>
-
         </div>
 
         <div class="form-group" *ngIf="snmpdevForm.controls.V3ContextEngineID">
           <label class="control-label col-sm-2" for="V3ContextEngineID">V3ContextEngineID</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMPV3 ContextEngineID in ScopedPDU (equivalent to the net-snmp -E paramenter)"></i>
           <div class="col-sm-9">
-            <input formControlName="V3ContextEngineID" id="V3ContextEngineID"  [ngModel]="snmpdevForm.value.V3ContextEngineID" />
+            <input formControlName="V3ContextEngineID" id="V3ContextEngineID" [ngModel]="snmpdevForm.value.V3ContextEngineID"  />
             <control-messages [control]="snmpdevForm.controls.V3ContextEngineID"></control-messages>
           </div>
         </div>
 
         <div class="form-group" *ngIf="snmpdevForm.controls.V3ContextName">
-
           <label class="control-label col-sm-2" for="V3ContextName">V3ContextName</label>
           <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="SNMPV3 ContextName in ScopedPDU ( equivalent to the net-snmp -n parameter)"></i>
           <div class="col-sm-9">
-            <input formControlName="V3ContextName" id="V3ContextName"  [ngModel]="snmpdevForm.value.V3ContextName" />
+            <input formControlName="V3ContextName" id="V3ContextName" [ngModel]="snmpdevForm.value.V3ContextName" />
             <control-messages [control]="snmpdevForm.controls.V3ContextName"></control-messages>
           </div>
         </div>
-      </div>
 
+      </div>
 
       <div class="form-group">
         <label class="control-label col-sm-2" for="Freq">Freq</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Frequency of polling (in seconds)"></i>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Frequency of snmp data polling (in seconds)"></i>
         <div class="col-sm-9">
           <input formControlName="Freq" id="Freq" [ngModel]="snmpdevForm.value.Freq" />
           <control-messages [control]="snmpdevForm.controls.Freq"></control-messages>
@@ -616,7 +271,7 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label col-sm-2" for="LogLevel">LogLevel</label>
+        <label class="control-label col-sm-2" for="LogLevel">Log level</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Severity log level"></i>
         <div class="col-sm-9">
           <select formControlName="LogLevel" id="LogLevel" [ngModel]="snmpdevForm.value.LogLevel">
@@ -624,7 +279,7 @@
             <option value="fatal">Fatal</option>
             <option value="error">Error</option>
             <option value="warn">Warning</option>
-            <option value="info">Info</option>
+            <option selected="selected" value="info">Info</option>
             <option value="debug">Debug</option>
           </select>
           <control-messages [control]="snmpdevForm.controls.LogLevel"></control-messages>
@@ -644,16 +299,16 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label col-sm-2" for="DeviceTagName">DeviceTagName</label>
+        <label class="control-label col-sm-2" for="DeviceTagName">Device Tag Name</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify type of device in InfluxDB"></i>
         <div class="col-sm-9">
-          <input formControlName="DeviceTagName" id="DeviceTagName" [ngModel]="snmpdevForm.value.DeviceTagName" />
+          <input formControlName="DeviceTagName" id="DeviceTagName" placeholder="device, host, switch..."  [ngModel]="snmpdevForm.value.DeviceTagName"/>
           <control-messages [control]="snmpdevForm.controls.DeviceTagName"></control-messages>
         </div>
       </div>
 
       <div class="form-group">
-        <label class="control-label col-sm-2" for="DeviceTagValue">DeviceTagValue</label>
+        <label class="control-label col-sm-2" for="DeviceTagValue">Device Tag Value</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify the device in InfluxDB"></i>
         <div class="col-sm-9">
           <select formControlName="DeviceTagValue" id="DeviceTagValue" [ngModel]="snmpdevForm.value.DeviceTagValue">
@@ -663,11 +318,12 @@
           <control-messages [control]="snmpdevForm.controls.DeviceTagValue"></control-messages>
         </div>
       </div>
+
       <div class="form-group">
         <label class="control-label col-sm-2" for="ExtraTags">ExtraTags</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag's value to identify the device in InfluxDB"></i>
         <div class="col-sm-9">
-          <input formControlName="ExtraTags" id="ExtraTags" [ngModel]='snmpdevForm.value.ExtraTags'>
+          <input formControlName="ExtraTags" id="ExtraTags" [ngModel]="snmpdevForm.value.ExtraTags" />
           <control-messages [control]="snmpdevForm.controls.ExtraTags"></control-messages>
         </div>
       </div>
@@ -689,11 +345,12 @@
           <control-messages [control]="snmpdevForm.controls.MeasFilters"></control-messages>
         </div>
       </div>
+
       <div class="form-group">
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Device"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='snmpdevForm.value.Description'> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="snmpdevForm.value.Description"> </textarea>
           <control-messages [control]="snmpdevForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -709,6 +366,7 @@
         <button type="button" [disabled]="!snmpdevForm.valid" (click)="showFilterModal()">Filter Connection</button>
       </div>
 
+
       <div class="col-sm-offset-2 col-sm-3">
         <button type="submit" [disabled]="!snmpdevForm.valid">Submit</button>
         <button type="reset" [disabled]="!snmpdevForm.dirty">Reset</button>
@@ -716,4 +374,4 @@
       </div>
     </form>
   </template>
-</p>
+</ng-container>

--- a/src/snmpmetric/snmpmetriceditor.html
+++ b/src/snmpmetric/snmpmetriceditor.html
@@ -1,7 +1,7 @@
 <h2>SNMP Metrics</h2>
 <h4 class="info-mode">{{ editmode | uppercase}} </h4>
 <hr>
-<p [ngSwitch]="editmode">
+<ng-container [ngSwitch]="editmode">
   <template ngSwitchCase="list">
     <test-modal #viewModal titleName='SNMP Metrics'></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this SNMP Metric will affect the following components','Deleting this SNMP Metric will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
@@ -33,146 +33,8 @@
     <pre *ngIf="config.paging" class="card card-block card-header">Page: {{page}} / {{numPages}}</pre>
   </template>
 
-  <template ngSwitchCase="create">
-    <form [formGroup]="snmpmetForm" class="form-horizontal" (ngSubmit)="saveSnmpMet()">
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="ID">ID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique metric identifier"></i>
-        <div class="col-sm-9">
-          <input formControlName="ID" id="ID" />
-          <control-messages [control]="snmpmetForm.controls.ID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="FieldName">Field Name</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Measurement's Field name"></i>
-        <div class="col-sm-9">
-          <input formControlName="FieldName" id="FieldName" />
-          <control-messages [control]="snmpmetForm.controls.FieldName"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="DataSrcType">DataSrcType</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
-        <div class="col-sm-9">
-          <select formControlName="DataSrcType" id="DataSrcType" (click)="setDynamicFields(snmpmetForm.value.DataSrcType, true);">
-            <option value="INTEGER">(SNMP SMI Type) INTEGER</option>
-            <option value="Integer32">(SNMP SMI Type) Integer32</option>
-            <option value="Gauge32">(SNMP SMI Type) Gauge32</option>
-            <option value="UInteger32">(SNMP SMI Type) UInteger32</option>
-            <option value="Unsigned32">(SNMP SMI Type) Unsigned32</option>
-            <option value="Counter32">(SNMP SMI Type) Counter32 </option>
-            <option value="Counter64">(SNMP SMI Type) Counter64 </option>
-            <option value="TimeTicks">(SNMP SMI Type) TimeTicks</option>
-            <option value="BITS">(SNMP SMI Type) BIT STRING (needs a named-number enumeration in extradata)</option>
-            <option value="OCTETSTRING">(SNMP SMI Type) OCTETSTRING</option>
-            <option value="OID">(SNMP SMI Type) OBJECT IDENTIFIER</option>
-            <option value="IpAddress">(SNMP SMI Type) IpAddress</option>
-            <option value="TIMETICKS">(Cooked type) TIMETICKS [Compute TimeTicks to seconds]</option>
-            <option value="COUNTER32">(Cooked type) COUNTER32 [Compute increments]</option>
-            <option value="COUNTER64">(Cooked type) COUNTER64 [Compute increments]</option>
-            <option value="COUNTERXX">(Cooked type) COUNTERXX [Compute non negative increments --for unknown range or buggy counter--]</option>
-            <option value="HWADDR">(Cooked type) HWADDR [ Translate Hardware Address (MAC) from STRING]</option>
-            <option value="STRINGPARSER">(Cooked type) STRINGPARSER [ Compute values from Regex ]</option>
-            <option value="STRINGEVAL">(Cooked type) STRINGEVAL [evaluate math expressions from other Field names in the mesurement]</option>
-            <option value="CONDITIONEVAL">(Cooked type) CONDITIONEVAL [evaluate OID table with boolean conditions and get number of true values ]</option>
-            <option value="BITSCHK">(Cooked Type) BIT STRING CHECK (needs the number bit to check in extradata , returns 1 or 0)</option>
-          </select>
-          <control-messages [control]="snmpmetForm.controls.DataSrcType"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="IsTag">IsTag</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="If true this OID will be sent to the Influxserver as a Tag Instead of a field on the measurement"></i>
-        <div class="col-sm-9">
-          <select formControlName="IsTag" id="IsTag">
-            <option value="true">(true) Use data as Tag</option>
-            <option value="false">(false) Use data as Field --default-- </option>
-          </select>
-          <control-messages [control]="snmpmetForm.controls.IsTag"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.BaseOID" >
-        <label class="control-label col-sm-2" for="BaseOID">Base OID</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of SNMP query"></i>
-        <div class="col-sm-9">
-          <input formControlName="BaseOID" id="BaseOID" />
-          <control-messages [(control)]="snmpmetForm.controls.BaseOID"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.GetRate">
-        <label class="control-label col-sm-2" for="GetRate">GetRate</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Normalize the returned value by time"></i>
-        <div class="col-sm-9">
-          <select formControlName="GetRate" id="GetRate">
-            <option value="true">True</option>
-            <option value="false">False</option>
-          </select>
-          <control-messages [control]="snmpmetForm.controls.GetRate"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && (snmpmetForm.value.DataSrcType == 'STRINGPARSER' || snmpmetForm.value.DataSrcType == 'STRINGEVAL' || snmpmetForm.value.DataSrcType == 'BITS'|| snmpmetForm.value.DataSrcType == 'BITSCHK' ) ">
-        <label class="control-label col-sm-2" for="ExtraData">ExtraData</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Extra data for the measurement"></i>
-        <div class="col-sm-9">
-          <input formControlName="ExtraData" id="ExtraData" />
-          <control-messages [control]="snmpmetForm.controls.ExtraData"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && snmpmetForm.value.DataSrcType == 'CONDITIONEVAL'">
-        <label class="control-label col-sm-2" for="ExtraData">ExtraData</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Selector of available OID conditions"></i>
-        <div class="col-sm-9">
-          <ss-multiselect-dropdown [options]="selectoidcond" formControlName="ExtraData" [texts]="myTexts" [settings]="mySettings"></ss-multiselect-dropdown>
-          <control-messages [control]="snmpmetForm.controls.ExtraData"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.Scale">
-        <label class="control-label col-sm-2" for="Scale">Scale</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Scale the returned value by a num"></i>
-        <div class="col-sm-9">
-          <input formControlName="Scale" id="Scale" />
-          <control-messages [control]="snmpmetForm.controls.Scale"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group" *ngIf="snmpmetForm.controls.Shift">
-        <label class="control-label col-sm-2" for="Shift">Shift</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Add a num to the returned (scaled) value "></i>
-        <div class="col-sm-9">
-          <input formControlName="Shift" id="Shift" />
-          <control-messages [control]="snmpmetForm.controls.Shift"></control-messages>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Metric"></i>
-        <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description"> </textarea>
-          <control-messages [control]="snmpmetForm.controls.Description"></control-messages>
-        </div>
-      </div>
-
-      <div class="col-sm-offset-4 col-sm-6">
-        <button type="submit" [disabled]="!snmpmetForm.valid">Submit</button>
-        <button type="reset" [disabled]="!snmpmetForm.dirty">Reset</button>
-        <button type="button" class="ui button" (click)="cancelEdit()">Cancel</button>
-      </div>
-    </form>
-
-  </template>
-
-  <template ngSwitchCase="modify">
-    <form [formGroup]="snmpmetForm" class="form-horizontal" (ngSubmit)="updateSnmpMet()">
+  <template ngSwitchDefault>
+    <form [formGroup]="snmpmetForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveSnmpMet() : updateSnmpMet()">
       <div class="form-group">
         <label class="control-label col-sm-2" for="ID">ID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique metric identifier"></i>
@@ -186,7 +48,7 @@
         <label class="control-label col-sm-2" for="FieldName">Field Name</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Measurement's Field name"></i>
         <div class="col-sm-9">
-          <input formControlName="FieldName" id="FieldName" [ngModel]="snmpmetForm.value.FieldName" />
+          <input formControlName="FieldName" id="FieldName" [ngModel]="snmpmetForm.value.FieldName"/>
           <control-messages [control]="snmpmetForm.controls.FieldName"></control-messages>
         </div>
       </div>
@@ -195,7 +57,7 @@
         <label class="control-label col-sm-2" for="DataSrcType">DataSrcType</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Retrieve value type"></i>
         <div class="col-sm-9">
-          <select formControlName="DataSrcType" id="DataSrcType" [ngModel]="snmpmetForm.value.DataSrcType" (click)="setDynamicFields(snmpmetForm.value.DataSrcType, true);">
+          <select formControlName="DataSrcType" id="DataSrcType" (click)="setDynamicFields(snmpmetForm.value.DataSrcType, true)" [ngModel]="snmpmetForm.value.DataSrcType">
             <option value="INTEGER">(SNMP SMI Type) INTEGER</option>
             <option value="Integer32">(SNMP SMI Type) Integer32</option>
             <option value="Gauge32">(SNMP SMI Type) Gauge32</option>
@@ -238,30 +100,28 @@
         <label class="control-label col-sm-2" for="BaseOID">Base OID</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Full OID or base OID (if indexed) of SNMP query"></i>
         <div class="col-sm-9">
-          <input formControlName="BaseOID" id="BaseOID" [ngModel]="snmpmetForm.value.BaseOID" />
-          <control-messages [control]="snmpmetForm.controls.BaseOID"></control-messages>
+          <input formControlName="BaseOID" id="BaseOID" [ngModel]="snmpmetForm.value.BaseOID"/>
+          <control-messages [(control)]="snmpmetForm.controls.BaseOID"></control-messages>
         </div>
       </div>
 
-      <div *ngIf="snmpmetForm.controls.GetRate">
-        <div class="form-group">
-          <label class="control-label col-sm-2" for="GetRate">GetRate</label>
-          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Normalize the returned value by time"></i>
-          <div class="col-sm-9">
-            <select formControlName="GetRate" id="GetRate" [ngModel]="snmpmetForm.value.GetRate">
-              <option value="true" selected="selected">True</option>
-              <option value="false">False</option>
-            </select>
-            <control-messages [control]="snmpmetForm.controls.GetRate"></control-messages>
-          </div>
+      <div class="form-group" *ngIf="snmpmetForm.controls.GetRate">
+        <label class="control-label col-sm-2" for="GetRate">GetRate</label>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Normalize the returned value by time"></i>
+        <div class="col-sm-9">
+          <select formControlName="GetRate" id="GetRate" [ngModel]="snmpmetForm.value.GetRate">
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+          <control-messages [control]="snmpmetForm.controls.GetRate"></control-messages>
         </div>
       </div>
 
-      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && (snmpmetForm.value.DataSrcType == 'STRINGPARSER' || snmpmetForm.value.DataSrcType == 'STRINGEVAL' || snmpmetForm.value.DataSrcType == 'BITS' || snmpmetForm.value.DataSrcType == 'BITSCHK' )">
+      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && (snmpmetForm.value.DataSrcType == 'STRINGPARSER' || snmpmetForm.value.DataSrcType == 'STRINGEVAL' || snmpmetForm.value.DataSrcType == 'BITS'|| snmpmetForm.value.DataSrcType == 'BITSCHK' ) ">
         <label class="control-label col-sm-2" for="ExtraData">ExtraData</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Extra data for the measurement"></i>
         <div class="col-sm-9">
-          <input formControlName="ExtraData" id="ExtraData" [ngModel]="snmpmetForm.value.ExtraData" />
+          <input formControlName="ExtraData" id="ExtraData" [ngModel]="snmpmetForm.value.ExtraData"/>
           <control-messages [control]="snmpmetForm.controls.ExtraData"></control-messages>
         </div>
       </div>
@@ -279,7 +139,7 @@
         <label class="control-label col-sm-2" for="Scale">Scale</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Scale the returned value by a num"></i>
         <div class="col-sm-9">
-          <input formControlName="Scale" id="Scale" [ngModel]="snmpmetForm.value.Scale" />
+          <input formControlName="Scale" id="Scale" [ngModel]="snmpmetForm.value.Scale"/>
           <control-messages [control]="snmpmetForm.controls.Scale"></control-messages>
         </div>
       </div>
@@ -288,7 +148,7 @@
         <label class="control-label col-sm-2" for="Shift">Shift</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Add a num to the returned (scaled) value "></i>
         <div class="col-sm-9">
-          <input formControlName="Shift" id="Shift" [ngModel]="snmpmetForm.value.Shift" />
+          <input formControlName="Shift" id="Shift" [ngModel]="snmpmetForm.value.Shift"/>
           <control-messages [control]="snmpmetForm.controls.Shift"></control-messages>
         </div>
       </div>
@@ -297,7 +157,7 @@
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Metric"></i>
         <div class="col-sm-9">
-          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]='snmpmetForm.value.Description'> </textarea>
+          <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="snmpmetForm.value.Description"> </textarea>
           <control-messages [control]="snmpmetForm.controls.Description"></control-messages>
         </div>
       </div>
@@ -309,4 +169,4 @@
       </div>
     </form>
   </template>
-</p>
+<ng-container>


### PR DESCRIPTION
### Tech
- Simplified create and modify templates on all components. This PR removes duplicated code on HTML so it simplifies coding over it

### Fixes
- Fix on new runtime filter button which was not filtering by not actived devices
- Small fix on Measurement Filters, the field EnableAlias was duplicated when the FilterType was set up with "file"
- Small fix on SNMPDevice community field. It was set up as a Static Field which was causing confusion when SNMPVersion v3 was selected