### PR TITLE
UI Fixed blank device vars inserted on DB, minor enhancements on multiselect dropdown to split id and name properties for options

### DIFF
--- a/src/common/multiselect-dropdown.ts
+++ b/src/common/multiselect-dropdown.ts
@@ -243,7 +243,9 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
             this.title = this.texts.defaultTitle;
         } else if (this.settings.dynamicTitleMaxItems >= this.numSelected) {
             if (this.settings.singleSelect === true) {
-                this.title = this.model.toString();
+                this.title = this.options
+                .filter((option) => this.model === option.id)
+                .map((fil) => fil.name).toString();
             } else {
                 this.title = this.options
                 .filter((option: IMultiSelectOption) => this.model && this.model.indexOf(option.id) > -1)

--- a/src/snmpdevice/snmpdevicecfg.component.ts
+++ b/src/snmpdevice/snmpdevicecfg.component.ts
@@ -154,7 +154,7 @@ export class SnmpDeviceCfgComponent {
       DeviceTagValue: [this.snmpdevForm ? this.snmpdevForm.value.DeviceTagValue : 'id'],
       ExtraTags: [this.snmpdevForm ? (this.snmpdevForm.value.ExtraTags ? this.snmpdevForm.value.ExtraTags : "" ) : "" , Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags])],
       SystemOIDs: [this.snmpdevForm ? (this.snmpdevForm.value.SystemOIDs ? this.snmpdevForm.value.SystemOIDs : "" ) : "" , Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags])],
-      DeviceVars: [this.snmpdevForm ? (this.snmpdevForm.value.DeviceVars ? this.snmpdevForm.value.DeviceVars : "" ) : ""],
+      DeviceVars: [this.snmpdevForm ? this.snmpdevForm.value.DeviceVars : null],
       MeasurementGroups: [this.snmpdevForm ? this.snmpdevForm.value.MeasurementGroups : null],
       MeasFilters: [this.snmpdevForm ? this.snmpdevForm.value.MeasFilters : null],
       Description: [this.snmpdevForm ? this.snmpdevForm.value.Description : ''],

--- a/src/snmpdevice/snmpdevicecfg.service.ts
+++ b/src/snmpdevice/snmpdevicecfg.service.ts
@@ -27,10 +27,11 @@ export class SnmpDeviceService {
         key == 'DisableBulk' ||
         key == 'ConcurrentGather') return ( value === "true" || value === true);
         if ( key == 'ExtraTags' ||
-             key == 'SystemOIDs' ||
-             key == 'DeviceVars' ) return  String(value).split(',');
+             key == 'SystemOIDs')
+             return  String(value).split(',');
         if ( key == 'MeasFilters' ||
-        key == 'MeasurementGroups') {
+        key == 'MeasurementGroups' ||
+        key == 'DeviceVars') {
             if (value == "") return null;
             else return value;
         }


### PR DESCRIPTION
### Fixes
- Fixed blank var inserted on DB when no `DeviceVar` was selected on form.

### Enhancements
- Split multiselect `id` and `name` option properties when is defined with single-select option