### PR TITLE
Add ENUM Cooked Metric Type

### DIFF
--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -323,6 +323,17 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 			s.Valid = true
 			s.log.Debugf("BITS CHECK bit %+v, Position %d , RESULT %t", barray, index, s.CookedValue)
 		}
+	case "ENUM":
+		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
+			idx := snmp.PduVal2Int64(pdu)
+			if val, ok := s.cfg.Names[int(idx)]; ok {
+				s.CookedValue = val
+			} else {
+				s.CookedValue = idx
+			}
+			s.Valid = true
+			s.log.Debugf("SETRAW ENUM %+v, RESULT %s", s.cfg.Names, s.CookedValue)
+		}
 	case "OCTETSTRING":
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
 			s.CookedValue = snmp.PduVal2str(pdu)

--- a/src/common/table-available-actions.ts
+++ b/src/common/table-available-actions.ts
@@ -142,7 +142,7 @@ export class AvailableTableActions {
       {'title': 'Change property', 'content' :
         {'type' : 'selector', 'action' : 'ChangeProperty', 'options' : [
           {'title' : 'DataSrcType', 'type':'boolean', 'options' : [
-            'INTEGER','Integer32','Gauge32','UInteger32','Unsigned32','Counter32','Counter64','TimeTicks','BITS','OCTETSTRING','OID','IpAddress','TIMETICKS','COUNTER32','COUNTER64','COUNTERXX','HWADDR','STRINGPARSER','STRINGEVAL','CONDITIONEVAL','BITSCHK'
+            'INTEGER','Integer32','Gauge32','UInteger32','Unsigned32','Counter32','Counter64','TimeTicks','BITS','ENUM','OCTETSTRING','OID','IpAddress','TIMETICKS','COUNTER32','COUNTER64','COUNTERXX','HWADDR','STRINGPARSER','STRINGEVAL','CONDITIONEVAL','BITSCHK'
             ]
           },
           {'title': 'Scale','type':'input', 'options':

--- a/src/snmpmetric/snmpmetriccfg.component.ts
+++ b/src/snmpmetric/snmpmetriccfg.component.ts
@@ -118,6 +118,7 @@ export class SnmpMetricCfgComponent {
     switch (field) {
       case 'BITS':
       case 'BITSCHK':
+      case 'ENUM':
         controlArray.push({'ID': 'ExtraData', 'defVal' : '', 'Validators' : Validators.required, 'override' : override });
         controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });
       case 'OCTETSTRING':

--- a/src/snmpmetric/snmpmetriceditor.html
+++ b/src/snmpmetric/snmpmetriceditor.html
@@ -77,6 +77,7 @@
             <option value="STRINGEVAL">(Cooked type) STRINGEVAL [evaluate math expressions from other Field names in the mesurement]</option>
             <option value="CONDITIONEVAL">(Cooked type) CONDITIONEVAL [evaluate OID table with boolean conditions and get number of true values ]</option>
             <option value="BITSCHK">(Cooked Type) BIT STRING CHECK (needs the number bit to check in extradata , returns 1 or 0)</option>
+            <option value="ENUM">(Cooked Type) ENUM (needs a named-number enumeration in extradata)</option>
             <option value="MULTISTRINGPARSER">(Cooked Type) MULTI-STRINGPARSER  (generates multiple fields or tags from an snmp returned string)</option>
           </select>
           <control-messages [control]="snmpmetForm.controls.DataSrcType"></control-messages>
@@ -104,7 +105,7 @@
         </div>
       </div>
 
-      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && (snmpmetForm.value.DataSrcType == 'STRINGPARSER' || snmpmetForm.value.DataSrcType == 'MULTISTRINGPARSER' || snmpmetForm.value.DataSrcType == 'STRINGEVAL' || snmpmetForm.value.DataSrcType == 'BITS'|| snmpmetForm.value.DataSrcType == 'BITSCHK' ) ">
+      <div class="form-group" *ngIf="snmpmetForm.controls.ExtraData && (snmpmetForm.value.DataSrcType == 'STRINGPARSER' || snmpmetForm.value.DataSrcType == 'MULTISTRINGPARSER' || snmpmetForm.value.DataSrcType == 'STRINGEVAL' || snmpmetForm.value.DataSrcType == 'BITS'|| snmpmetForm.value.DataSrcType == 'ENUM'|| snmpmetForm.value.DataSrcType == 'BITSCHK' ) ">
         <label class="control-label col-sm-2" for="ExtraData">ExtraData</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Extra data for the measurement"></i>
         <div class="col-sm-9">


### PR DESCRIPTION
Sometimes we need to replace numbers with some text. For example, ifType is better read as `ethernetCsmacd(6)` istead of `6`.

ENUM is used like BIT STRING, but instead of checking bit values, it checks for the number.

With ifType we can now make new metric, for example, `ifType-switch`, then set `isTag` to `True`, `Base OID` to `.1.3.6.1.2.1.2.2.1.3` and `ExtraData` to `ethernetCsmacd(6) mpls(166) other(1) propVirtual(53) softwareLoopback(24)`. And as a result we have a nice readable tag instead of number.

![image](https://user-images.githubusercontent.com/3754755/36670502-6f315194-1b1a-11e8-83d7-5fd280cb2c6c.png)
