### PR TITLE
ENUM should always return a string

### DIFF
--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -329,7 +329,7 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 			if val, ok := s.cfg.Names[int(idx)]; ok {
 				s.CookedValue = val
 			} else {
-				s.CookedValue = idx
+				s.CookedValue = strconv.Itoa(int(idx))
 			}
 			s.Valid = true
 			s.log.Debugf("SETRAW ENUM %+v, RESULT %s", s.cfg.Names, s.CookedValue)


### PR DESCRIPTION
Fixes #329, ENUM returned raw value as int64 when there was no match for index in ENUM list.