### PR TITLE
Fix create/edit Measurements with stringeval + multistringparser and fix panic on no capturing group on tag multistringparser metrics

### DIFF
--- a/pkg/config/measurementcfg.go
+++ b/pkg/config/measurementcfg.go
@@ -71,22 +71,15 @@ func (mc *MeasurementCfg) CheckComputedMetricVars(parameters map[string]interfac
 
 // CheckComputedMetricEval check for computed metrics based on  Evalutation Execution
 func (mc *MeasurementCfg) CheckComputedMetricEval(parameters map[string]interface{}) error {
-
-	log.Debugf("Building check parrameters array for index measurement %s", mc.ID)
-	parameters["NFR"] = 1
-	parameters["NR"] = 1                                           //Number of rows (like awk)
-	parameters["NF"] = len(mc.FieldMetric) + len(mc.OidCondMetric) //Number of fields ( like awk)
-	//getting all values to the array
-	for _, v := range mc.FieldMetric {
-		parameters[v.FieldName] = float64(1)
-	}
-	for _, v := range mc.OidCondMetric {
-		parameters[v.FieldName] = float64(1)
-	}
-	log.Debugf("PARAMETERS: %+v", parameters)
-	//compute Evalutated metrics
 	var err error
 	var errstr []string
+	//get all the eval parameters
+	ep, _ := mc.GetEvaluableVarNames()
+	for _, t := range ep {
+		parameters[t] = float64(1)
+	}
+	parameters["NF"] = len(mc.FieldMetric) + len(mc.OidCondMetric) //Number of fields ( like awk)
+	log.Debugf("PARAMETERS: %+v", parameters)
 	for _, v := range mc.EvalMetric {
 		err = v.CheckEvalCfg(parameters)
 		if err != nil {

--- a/pkg/config/snmpmetriccfg.go
+++ b/pkg/config/snmpmetriccfg.go
@@ -188,14 +188,24 @@ func (m *SnmpMetricCfg) GetMultiStringTagFieldMap() ([]*MetricMultiMap, error) {
 		if iType == "F" {
 			iConv = "INT"
 		}
-		if len(itcfg) > 2 {
+		if len(itcfg) > 2 && iType == "F" {
 			switch itcfg[2] {
 			case "STR":
 			case "BL":
 			case "INT":
 			case "FP":
 			default:
-				str := fmt.Sprintf("MultiString Parse Config error on Metric %s Conversion Type (%s) should be of type STR|INT|FP|BL", m.ID, itcfg[2])
+				str := fmt.Sprintf("MultiString Parse Config error on Metric %s Conversion Type (%s) for FIELD should be of type STR|INT|FP|BL", m.ID, itcfg[2])
+				log.Errorf(str)
+				return nil, errors.New(str)
+			}
+			iConv = itcfg[2]
+		}
+		if len(itcfg) > 2 && iType == "T" {
+			switch itcfg[2] {
+			case "STR":
+			default:
+				str := fmt.Sprintf("MultiString Parse Config error on Metric %s Conversion Type (%s) for TAG should be of type STR", m.ID, itcfg[2])
 				log.Errorf(str)
 				return nil, errors.New(str)
 			}

--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -540,6 +540,7 @@ func (s *SnmpMetric) computeMultiStringParserValues() {
 		}
 		if err != nil {
 			s.log.Warnf("Error for Metric %s MULTISTRINGPARSER  Field [%s|%s|%s] Coversion  from  [%s] error: %s", s.cfg.ID, i.IType, i.IName, i.IConv, bitstr, err)
+			i.Value = nil
 		}
 	}
 }
@@ -550,10 +551,12 @@ func (s *SnmpMetric) addMultiStringParserValues(tags map[string]string, fields m
 	for _, i := range s.mm {
 		switch i.IType {
 		case "T":
+			if i.Value == nil {
+				continue
+			}
 			tags[i.IName] = i.Value.(string)
 		case "F":
 			fields[i.IName] = i.Value
-
 		}
 	}
 	return fErrors


### PR DESCRIPTION
### Fixes

- Fix unable to create/edit measurement with STRINGEVAL metrics based on MULTISTRINGPARSER fields/tags. Fix #335 
- Fix panic on nil capturing group on MULTISTRINGPARSER Tag string. Set STR as only possible type on MULTISTRINGPARSER Tag. Fix #336 
