### PR TITLE
Add new runtime operations from device config

### DIFF
--- a/pkg/webui/apicfg-snmpdevice.go
+++ b/pkg/webui/apicfg-snmpdevice.go
@@ -90,7 +90,15 @@ func AddSNMPDevice(ctx *Context, dev config.SnmpDeviceCfg) {
 	mode := ctx.Params(":mode")
 	log.Printf("ADDING DEVICE %+v mode(%s)", dev, mode)
 	switch mode {
-	case "online":
+	case "runtime":
+		err := addDeviceOnline("deploy", dev.ID, &dev)
+		if err != nil {
+			log.Warningf("Error on insert for device %s  , error: %s", dev.ID, err)
+			ctx.JSON(404, err.Error())
+		} else {
+			ctx.JSON(200, &dev)
+		}
+	case "full":
 		err := addDeviceOnline("add", dev.ID, &dev)
 		if err != nil {
 			log.Warningf("Error on insert for device %s  , error: %s", dev.ID, err)
@@ -117,7 +125,22 @@ func UpdateSNMPDevice(ctx *Context, dev config.SnmpDeviceCfg) {
 	mode := ctx.Params(":mode")
 	log.Printf("UPDATING DEVICE %s in mode(%s)", id, mode)
 	switch mode {
-	case "online":
+	case "runtime":
+		var err error
+		err = agent.DeleteDeviceInRuntime(id)
+		if err != nil {
+			log.Warningf("Error on online delete device %s  , error %s", dev.ID, err)
+			ctx.JSON(404, err.Error())
+			return
+		}
+		err = addDeviceOnline("deploy", id, &dev)
+		if err != nil {
+			log.Warningf("Error on insert for device %s  , error: %s", dev.ID, err)
+			ctx.JSON(404, err.Error())
+		} else {
+			ctx.JSON(200, &dev)
+		}
+	case "full":
 		var err error
 		err = agent.DeleteDeviceInRuntime(id)
 		if err != nil {
@@ -152,7 +175,16 @@ func DeleteSNMPDevice(ctx *Context) {
 	mode := ctx.Params(":mode")
 	log.Printf("DELETING DEVICE %s in mode(%s)", id, mode)
 	switch mode {
-	case "online":
+	case "runtime":
+		err := agent.DeleteDeviceInRuntime(id)
+		if err != nil {
+			log.Warningf("Error on online delete device %s  , error %s", id, err)
+			ctx.JSON(404, err.Error())
+			return
+		} else {
+			ctx.JSON(200, "deleted")
+		}
+	case "full":
 		err := agent.DeleteDeviceInRuntime(id)
 		if err != nil {
 			log.Warningf("Error on online delete device %s  , error %s", id, err)

--- a/src/common/blockui/blockui-service.ts
+++ b/src/common/blockui/blockui-service.ts
@@ -1,7 +1,5 @@
 import { Injectable, ApplicationRef, ViewContainerRef, Component, ComponentRef, ComponentFactoryResolver, ComponentFactory, ViewChild } from '@angular/core';
-
-import { BlockUIComponent } from './blockui-component'; // error here, wrong path
-
+import { BlockUIComponent } from './blockui-component';
 
 @Injectable()
 export class BlockUIService {
@@ -10,9 +8,8 @@ export class BlockUIService {
     constructor(private _appRef: ApplicationRef, private _resolver: ComponentFactoryResolver) {
     }
 
-    public start(placeholder, prop) { // placeholder missing!
-        //let elementRef: ViewContainerRef = (<any>this._appRef)['_rootComponents'][0].location; // remove this
-        let elementRef = placeholder; // add this
+    public start(placeholder, prop) {
+        let elementRef = placeholder;
         return this.startInside(elementRef, null, prop);
     }
 

--- a/src/common/blockui/blockui.css
+++ b/src/common/blockui/blockui.css
@@ -1,13 +1,14 @@
 .block-overlay {
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color:#2E6DA4;
   cursor: wait;
 }
 .block-message-container {
-  position: absolute;
-  top: 35%;
+  position: fixed;
+  background-color: white;
+  top: 30%;
   left: 0;
   right: 0;
-  height: 0;
+  height: 100px;
   text-align: center;
   z-index: 10001;
   cursor: wait;

--- a/src/common/ng-table/components/table/ng-table.html
+++ b/src/common/ng-table/components/table/ng-table.html
@@ -14,6 +14,14 @@
                 </th>
             </ng-container>
             <!--HEADER -->
+            <ng-container *ngIf="extraActions">
+                    <ng-container *ngIf="extraActions['position'] === 'first'">
+                
+                <th *ngFor="let action of extraActions['data'] " style="vertical-align: middle; text-align: center; min-width:125px !important; ">
+                    {{action.title}}
+                </th>
+                </ng-container>
+            </ng-container>
             <th *ngFor="let column of columns" [ngTableSorting]="config" [column]="column" (sortChanged)="onChangeTable($event)" ngClass="{{column.className || ''}}" style="vertical-align: middle; text-align: center; width:auto !important; white-space:nowrap" container=body [tooltip]="column.tooltipInfo ? tooltipValues : ( column.tooltip ? column.name : '')">
                 <ng-template #tooltipValues>
                     <ng-container>
@@ -32,10 +40,13 @@
                 <span *ngIf="column.tooltipInfo && column.tooltipInfo.IsTag" class="badge">Tag</span>
                 <small *ngIf="config" style="display:inline" class="glyphicon text-muted" [ngClass]="{ 'glyphicon-sort' : column.sort === '' || !column.sort, 'glyphicon-chevron-down': column.sort==='desc' , 'glyphicon-chevron-up': column.sort==='asc' } "></small>
             </th>
-            <ng-container *ngIf="extraActions ">
-                <th *ngFor="let action of extraActions " style="vertical-align: middle; text-align: center; width:auto !important; ">
+            <ng-container *ngIf="extraActions">
+                    <ng-container *ngIf="extraActions['position'] === 'last'">
+                
+                <th *ngFor="let action of extraActions['data'] " style="vertical-align: middle; text-align: center; width:auto !important; ">
                     {{action.title}}
                 </th>
+                </ng-container>
             </ng-container>
         </tr>
     </thead>
@@ -58,6 +69,10 @@
                 <i *ngFor="let action of roleActions" [ngClass]="action.icon" [tooltip]="action.tooltip" (click)="customClick(action.name, row)" style="padding-left:5px">
                 </i>
             </td>
+        <ng-container *ngIf="extraActions">
+            <ng-container *ngIf="extraActions['position'] === 'first'; then extraActionsContent">
+            </ng-container>
+        </ng-container>
             <td *ngIf="showStatus==true " style="min-width: 170px ">
                 <label style="display: inline; margin-right: 2px " container=body [tooltip]=" 'View '+ row.ID " class="label label-primary glyphicon glyphicon-eye-open " (click)="viewItem(row) "></label>
                 <span style="border-right: 1px solid #1B809E; padding-right: 6px ">
@@ -93,16 +108,22 @@
                 </ng-template>
 
             </td>
-            <ng-container *ngIf="extraActions ">
-                <td *ngFor="let action of extraActions " style="text-align: center ">
-                    <button *ngIf="action.type=='boolean' " (click)="extraActionClick(row,action.title,!row[action.property]) " [ngClass]="row[action.property] ? [ 'btn btn-success'] : [ 'btn btn-danger'] " [innerHtml]="row[action.property] ? action.content[
-        'enabled'] : action.content[ 'disabled'] ">
-      </button>
-                    <button *ngIf="action.type=='button' " class="btn btn-primary " (click)="extraActionClick(row,action.title) ">
-        <span>{{action.content['enabled']}}</span>
-      </button>
-                </td>
+            
+            <ng-container *ngIf="extraActions">
+            <ng-container *ngIf="extraActions['position'] === 'last'; then extraActionsContent">
             </ng-container>
+        </ng-container>
+            
+            <ng-template #extraActionsContent>
+                <td *ngFor="let action of extraActions['data'] " style="text-align: center ">
+                    <ng-container *ngFor="let i of action.content">
+                        <label  *ngIf="i.type=='boolean-label'"role="button"  [tooltip]= "i.tooltip" container=body (click)="extraActionClick(row,i.action,i.property) " [ngClass]="row[i.property] ? [ 'label label-success'] : [ 'label label-danger'] " [innerHtml]="row[i.property] ? i['enabled'] : i['disabled'] "></label>
+                        <button *ngIf="i.type=='boolean'" [tooltip]= "i.tooltip" container=body (click)="extraActionClick(row,i.action,i.property) " [ngClass]="row[i.property] ? [ 'btn btn-success'] : [ 'btn btn-danger'] " [innerHtml]="row[i.property] ? i['enabled'] : i['disabled'] "></button>                     
+                        <label *ngIf="i.type=='button-label'" role="button"  [tooltip]= "i.tooltip" container=body class="label label-primary " (click)="extraActionClick(row,i.action)" [innerHtml]="i['text']"></label>
+                        <button *ngIf="i.type=='button'" [tooltip]= "i.tooltip" container=body class="btn btn-primary " (click)="extraActionClick(row,i.action)" [innerHtml]="i['text']"></button>
+                    </ng-container>
+                </td>
+            </ng-template>
         </tr>
     </tbody>
 </table>

--- a/src/common/table-list.component.ts
+++ b/src/common/table-list.component.ts
@@ -56,7 +56,10 @@ declare var _: any;
       (tableChanged)="onChangeTable(config)"
       (customClicked)="customClick($event.action, $event.row)"
       [tableRole]="tableRole"
-      [roleActions]="roleActions">
+      [roleActions]="roleActions"
+      [extraActions]="extraActions"
+      (extraActionClicked)="extraActionClick($event)"
+      >
     </ng-table>
 
     <!-- Pagination -->
@@ -85,11 +88,14 @@ export class TableListComponent implements OnInit, OnChanges {
     {'name':'edit', 'type':'icon', 'icon' : 'glyphicon glyphicon-edit text-warning', 'tooltip': 'Edit item'},
     {'name':'remove', 'type':'icon', 'icon' : 'glyphicon glyphicon glyphicon-remove text-danger', 'tooltip': 'Remove item'}
   ]
+  @Input() extraActions : any = null;
 
   @Input() sanitizeCell: Function;
   @Input() public tableAvailableActions: any;
 
   @Output() public customClicked: EventEmitter<any> = new EventEmitter();
+  @Output() public extraActionClicked: EventEmitter<any> = new EventEmitter();
+
 
   //Vars
   public editEnabled: boolean = false;
@@ -244,5 +250,8 @@ export class TableListComponent implements OnInit, OnChanges {
   customClick(clicked: string, event: any = "", data: any = ""): void {
     this.customClicked.emit({ 'option': clicked, 'event': event, 'data': data });
   }
-
+  
+  public extraActionClick(event) : void {
+    this.extraActionClicked.emit(event);
+  }
 }

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -1,4 +1,4 @@
-<div #blocker></div>
+<div #blocker style="position: absolute; top: 50%;"></div>
 <ng-container *ngIf="userIn === true">
     <about-modal #aboutModal [showValidation]="true" titleName='About'></about-modal>
     <nav class="navbar navbar-inverse navbar-fixed-top" style="z-index:1000">

--- a/src/runtime/runtime.data.ts
+++ b/src/runtime/runtime.data.ts
@@ -14,33 +14,54 @@ export const RuntimeComponentConfig: any =
     ],
   }; 
 
-  export const TableRole : string = 'runtime';
+export const TableRole : string = 'runtime';
 
-  export const ExtraActions: Array<any> = [
-    { title: 'SetActive', type: 'boolean', content: { enabled: '<i class="glyphicon glyphicon-pause"></i>', disabled: '<i class="glyphicon glyphicon-play"></i>' }, 'property': 'DeviceActive' },
-    { title: 'SnmpReset', type: 'button', content: { enabled: 'Reset' } }
-  ];
+export const ExtraActions: Object = {
+  data: [
+    { 
+      title: 'SetActive', content: [
+        { 
+          type: 'boolean',
+          enabled: '<i class="glyphicon glyphicon-pause"></i>',
+          disabled: '<i class="glyphicon glyphicon-play"></i>',
+          property: 'DeviceActive',
+          action: "SetActive"
+        }
+      ] 
+    },
+    { 
+      title: 'SnmpReset', content: [
+        {
+          type: 'button', 
+          text: '<span>Reset</span>', 
+          action: 'SnmpReset'
+        }
+      ] 
+    }
+  ],
+  "position": "last"
+};
 
-  export const CounterDef: CounterType[] = [
-    /*0*/    { show: false, id: "SnmpGetQueries", label: "SnmpGet Queries", type: "counter", tooltip: "number of snmp queries" },
-    /*1*/    { show: false, id: "SnmpWalkQueries", label: "SnmpWalk Queries", type: "counter", tooltip: "number of snmp walks" },
-    /*2*/    { show: false, id: "SnmpGetErrors", label: "SnmpGet Errors", type: "counter", tooltip: "Get Error" },
-    /*3*/    { show: false, id: "SnmpWalkErrors", label: "SnmpWalk Errors", type: "counter", tooltip: "Walk Error" },
-    /*4*/    { show: false, id: "SnmpQueryTimeouts", label: "Snmp Errors by Timeout", type: "counter", tooltip: "number of registered errors by timeouts" },
-    /*5*/    { show: true, id: "SnmpOIDGetAll", label: "OID Gets ALL", type: "counter", tooltip: "All Gathered snmp metrics ( sum of snmpget oid's and all received oid's in snmpwalk queries)" },
-    /*6*/    { show: true, id: "SnmpOIDGetProcessed", label: "OID Processed", type: "counter", tooltip: "Gathered and processed snmp metrics after filters are applied ( not always sent to the backend it depens on the report flag)" },
-    /*7*/    { show: true, id: "SnmpOIDGetErrors", label: "OID With Errors", type: "counter", tooltip: "number of  oid with errors for all measurements" },
-    /*8*/    { show: false, id: "EvalMetricsAll", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics" },
-    /*9*/    { show: false, id: "EvalMetricsOk", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics without errors." },
-    /*10*/    { show: false, id: "EvalMetricsErrors", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics with some kind of error." },
-    /*11*/    { show: true, id: "MetricSent", label: "Metric Sent", type: "counter", tooltip: "number of metrics sent (taken as fields) for all measurements" },
-    /*12*/    { show: true, id: "MetricSentErrors", label: "Metric Sent Errors", type: "counter", tooltip: "number of metrics  (taken as fields) with errors forall measurements" },
-    /*13*/    { show: true, id: "MeasurementSent", label: "Measurement sent", type: "counter", tooltip: "(number of  measurements build to send as a sigle request sent to the backend)" },
-    /*14*/    { show: true, id: "MeasurementSentErrors", label: "Measurement sent Errors", type: "counter", tooltip: "(number of measuremenets  formatted with errors )" },
-    /*15*/    { show: false, id: "CycleGatherStartTime", label: "Cycle Gather Start Time", type: "time", tooltip: "Last gather time " },
-    /*16*/    { show: true, id: "CycleGatherDuration", label: "Cycle Gather Duration", type: "duration", tooltip: "elapsed time taken to get all measurement info" },
-    /*17*/    { show: false, id: "FilterStartTime", label: "Filter update Start Time", type: "time", tooltip: "Last Filter time" },
-    /*18*/    { show: true, id: "FilterDuration", label: "Filter update Duration", type: "duration", tooltip: "elapsed time taken to compute all applicable filters on the device" },
-    /*19*/    { show: false, id: "BackEndSentStartTime", label: "BackEnd (influxdb) Sent Start Time", type: "time", tooltip: "Last sent time" },
-    /*20*/    { show: true, id: "BackEndSentDuration", label: "BackEnd (influxdb) Sent Duration", type: "duration", tooltip: "elapsed time taken to send data to the db backend" },
-    ];
+export const CounterDef: CounterType[] = [
+  /*0*/    { show: false, id: "SnmpGetQueries", label: "SnmpGet Queries", type: "counter", tooltip: "number of snmp queries" },
+  /*1*/    { show: false, id: "SnmpWalkQueries", label: "SnmpWalk Queries", type: "counter", tooltip: "number of snmp walks" },
+  /*2*/    { show: false, id: "SnmpGetErrors", label: "SnmpGet Errors", type: "counter", tooltip: "Get Error" },
+  /*3*/    { show: false, id: "SnmpWalkErrors", label: "SnmpWalk Errors", type: "counter", tooltip: "Walk Error" },
+  /*4*/    { show: false, id: "SnmpQueryTimeouts", label: "Snmp Errors by Timeout", type: "counter", tooltip: "number of registered errors by timeouts" },
+  /*5*/    { show: true, id: "SnmpOIDGetAll", label: "OID Gets ALL", type: "counter", tooltip: "All Gathered snmp metrics ( sum of snmpget oid's and all received oid's in snmpwalk queries)" },
+  /*6*/    { show: true, id: "SnmpOIDGetProcessed", label: "OID Processed", type: "counter", tooltip: "Gathered and processed snmp metrics after filters are applied ( not always sent to the backend it depens on the report flag)" },
+  /*7*/    { show: true, id: "SnmpOIDGetErrors", label: "OID With Errors", type: "counter", tooltip: "number of  oid with errors for all measurements" },
+  /*8*/    { show: false, id: "EvalMetricsAll", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics" },
+  /*9*/    { show: false, id: "EvalMetricsOk", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics without errors." },
+  /*10*/    { show: false, id: "EvalMetricsErrors", label: "Evaluated Metrics", type: "counter", tooltip: "number of evaluated metrics with some kind of error." },
+  /*11*/    { show: true, id: "MetricSent", label: "Metric Sent", type: "counter", tooltip: "number of metrics sent (taken as fields) for all measurements" },
+  /*12*/    { show: true, id: "MetricSentErrors", label: "Metric Sent Errors", type: "counter", tooltip: "number of metrics  (taken as fields) with errors forall measurements" },
+  /*13*/    { show: true, id: "MeasurementSent", label: "Measurement sent", type: "counter", tooltip: "(number of  measurements build to send as a sigle request sent to the backend)" },
+  /*14*/    { show: true, id: "MeasurementSentErrors", label: "Measurement sent Errors", type: "counter", tooltip: "(number of measuremenets  formatted with errors )" },
+  /*15*/    { show: false, id: "CycleGatherStartTime", label: "Cycle Gather Start Time", type: "time", tooltip: "Last gather time " },
+  /*16*/    { show: true, id: "CycleGatherDuration", label: "Cycle Gather Duration", type: "duration", tooltip: "elapsed time taken to get all measurement info" },
+  /*17*/    { show: false, id: "FilterStartTime", label: "Filter update Start Time", type: "time", tooltip: "Last Filter time" },
+  /*18*/    { show: true, id: "FilterDuration", label: "Filter update Duration", type: "duration", tooltip: "elapsed time taken to compute all applicable filters on the device" },
+  /*19*/    { show: false, id: "BackEndSentStartTime", label: "BackEnd (influxdb) Sent Start Time", type: "time", tooltip: "Last sent time" },
+  /*20*/    { show: true, id: "BackEndSentDuration", label: "BackEnd (influxdb) Sent Duration", type: "duration", tooltip: "elapsed time taken to send data to the db backend" },
+];

--- a/src/snmpdevice/snmpdevicecfg.data.ts
+++ b/src/snmpdevice/snmpdevicecfg.data.ts
@@ -28,6 +28,38 @@ export const SnmpDeviceCfgComponentConfig: any =
     'slug' : 'snmpdevicecfg'
   }; 
 
+export const ExtraActions: any = {
+  data: [
+    {
+      title: 'Runtime Ops', content: [
+        {
+          type: 'boolean-label', 
+          enabled: '<label class="glyphicon glyphicon-minus-sign"></label>',
+          disabled: '<i role="button" class="glyphicon glyphicon-plus-sign"></i>',
+          property: 'IsRuntime', 
+          action: 'changeruntime',
+          tooltip: 'Un/Deploy device in runtime'
+        },
+        {
+          type: 'boolean-label', 
+          enabled: '<label class="glyphicon glyphicon-refresh"></label>',
+          disabled: null,
+          property: 'IsRuntime', 
+          action: 'updateruntime',
+          tooltip: 'Refresh device configuration in runtime'
+        },
+        {
+          type: 'button-label',
+          text: '<label role="button" class="glyphicon glyphicon-remove-sign"></label>',
+          property: 'Active',
+          action: 'deletefull',
+          tooltip: 'Delete in runtime and config'
+        }
+      ]
+    }],
+  position: 'first'
+};
+  
   export const TableRole : string = 'fulledit';
   export const OverrideRoleActions : Array<Object> = [
     {'name':'export', 'type':'icon', 'icon' : 'glyphicon glyphicon-download-alt text-default', 'tooltip': 'Export item'},

--- a/src/snmpdevice/snmpdevicecfg.service.ts
+++ b/src/snmpdevice/snmpdevicecfg.service.ts
@@ -38,38 +38,39 @@ export class SnmpDeviceService {
         return value;
     }
 
-    addDevice(dev,online?) {
+    addDevice(dev,mode?) {
         var url = '/api/cfg/snmpdevice/';
-        if ( online == true ) {
-            url +='/online'
+        if (mode) {
+            url += mode
         }
         return this.httpAPI.post(url,JSON.stringify(dev,this.parseJSON))
         .map( (responseData) => responseData.json());
     }
 
-    editDevice(dev, id, online,hideAlert?) {
-        console.log("DEV: ",dev);
+    editDevice(dev, id, mode?,hideAlert?) {
+        console.log("DEV: ",dev,mode);
         var url = '/api/cfg/snmpdevice/'+id;
-        if ( online == true ) {
-            url +='/online'
+        if (mode) {
+            url += '/'+mode
         }
+        console.log("URL",url);
         //TODO: Se tiene que coger el oldid para substituir en la configuración lo que toque!!!!
         return this.httpAPI.put(url,JSON.stringify(dev,this.parseJSON),null,hideAlert)
         .map( (responseData) => responseData.json());
     }
 
-    deleteDevice(id : string, online,hideAlert?) {
+    deleteDevice(id : string, mode?,hideAlert?) {
         // return an observable
         console.log("ID: ",id);
         console.log("DELETING");
         var url = '/api/cfg/snmpdevice/'+id;
-        if ( online == true ) {
-            url +='/online'
+        if (mode) {
+            url += '/'+mode
         }
         return this.httpAPI.delete(url, null, hideAlert)
-        .map( (responseData) =>
-         responseData.json()
-        );
+        .map( (responseData) => {
+            responseData.json();
+        })
     };
 
 

--- a/src/snmpdevice/snmpdeviceeditor.html
+++ b/src/snmpdevice/snmpdeviceeditor.html
@@ -1,6 +1,7 @@
 <h2>{{defaultConfig.name}}</h2>
 <test-connection-modal #viewTestConnectionModal titleName='Test connection for:'>
 </test-connection-modal>
+<div #blocker style="position: absolute; top: 50%;"></div>
 <ng-container [ngSwitch]="editmode">
     <ng-template ngSwitchCase="list">
     <test-modal #viewModal titleName='Device'></test-modal>
@@ -9,12 +10,13 @@
     </test-modal>
     <export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
     <table-list #listTableComponent [typeComponent]="defaultConfig['slug']" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting" [tableRole]="tableRole"
-    [roleActions]="overrideRoleActions" overrideEditEnabled="true" [tableAvailableActions]="tableAvailableActions" (customClicked)="customActions($event)"></table-list>
+    [roleActions]="overrideRoleActions" [extraActions]="extraActions" overrideEditEnabled="true" [tableAvailableActions]="tableAvailableActions" (customClicked)="customActions($event)"
+    (extraActionClicked)="onExtraActionClicked($event)"></table-list>
     </ng-template>
     <ng-template ngSwitchDefault>
     <test-filter-modal #viewTestFilterModal titleName='Filter connection:' [formValues]="snmpdevForm.value">
     </test-filter-modal>
-    <form [formGroup]="snmpdevForm" class="form-horizontal" (ngSubmit)="doOffline()">
+    <form [formGroup]="snmpdevForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveSnmpDev(snmpdevForm.value) : updateSnmpDev(false,snmpdevForm.value)">
       <ng-container>
         <div class="row well well-sm">
           <h4 style="display:inline">
@@ -26,8 +28,7 @@
           <div style="display:inline" tooltip='Submit' container=body><button class="btn btn-success" type="submit" [disabled]="!snmpdevForm.valid"> <i class="glyphicon glyphicon-ok-circle"></i></button></div>
           <div style="display:inline" tooltip='Reset' container=body><button class="btn btn-warning" type="reset" [disabled]="!snmpdevForm.dirty"><i class="glyphicon glyphicon-ban-circle"></i> </button></div>
           <div style="display:inline" tooltip='Cancel' container=body><button class="btn btn-danger" type="button" (click)="cancelEdit()"><i class="glyphicon glyphicon-remove-circle"></i></button></div>
-          <div style="display:inline" tooltip='Submit and Apply changes Online' container=body><button class="btn btn-success" type="button" (click)="doOnline()"><i class="glyphicon glyphicon-adjust"></i></button></div>
-
+          <div style="display:inline; margin-left: 10px; border-left: 1px solid #337ab7" tooltip='Submit and apply changes on runtime' container=body ><button  class="btn btn-success" style="margin-left: 10px;" type="button" (click)="editmode === 'create' ? saveSnmpDev(snmpdevForm.value,'full') : updateSnmpDev(false,snmpdevForm.value,'full')"><i class="glyphicon glyphicon-adjust"></i></button></div>
         </div>
       </div>
     </ng-container>


### PR DESCRIPTION
## Features
Added runtime operations on device configuration. This PR extends to the user to the available actions from device configurations to change runtime without reload config. This PR implements #349 

### UI
It has been implemented adding a new column on list and a button when edit/creating:
* List
![image](https://user-images.githubusercontent.com/13196237/41541802-9e9816c4-7313-11e8-8abc-7d045120f27d.png) 

* New/Edit
![image](https://user-images.githubusercontent.com/13196237/41546588-54cb84a8-731e-11e8-95f6-f4992e5aedf6.png)

On the following table are described the new available ops:

Mode | Action | Available from | Description
-- | -- | -- | --
full | Add | Add/Edit device   forms | Allows to add a   device in configuration and deploy it on runtime
full | Update | Add/Edit device form | Allows to update   device in config and runtime
full | Delete | Devices list | Allows to do a full   delete of device  in runtime and   configuration
runtime | Deploy/undeploy | Devices list | Allows to  deploy/undeploy a device in runtime
runtime | Update | Devices list | Allows to update  runtime device configuration


### API
On the API side, the following URLs are enabled in order to automate adding/update/delete operations:

Action | Method | URL | Mode parameters | Description
-- | -- | -- | -- | --
Add new device | POST | /api/cfg/snmpdevice/:mode | <li>runtime </li><li> full </li> | Add new device on runtime (runtime) or full (runtime + config)
Update device | PUT | /api/cfg/snmpdevice/:id/:mode | <li>runtime </li><li> full </li> | Allows to update device on runtime (runtime) or full (runtime + config)
Delete device | DELETE | /:id/:mode | <li>runtime </li><li> full </li> | Allows to delete device on runtime (runtime) or full (runtime + config)
