### PR TITLE
Add conversion to snmpmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 0.8.0 ( unreleased ) 
 ### New Features
 * Added new capabilities to add , modify and delete devices online ( avoids restart the gathering ocess  on the other devices) 
+* Go 1.9.8 to 1.11 binaries 
 
 # v 0.7.7 (2018-05-28)
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 ### New Features
 * Added new capabilities to add , modify and delete devices online ( avoids restart the gathering ocess  on the other devices) 
 * Go 1.9.8 to 1.11 binaries 
+* Added a new Conversión parameter to most of the snmpmetric types.
+* Implement HexString to INTEGUER conversion , implements #310
+
+### fixes
+
+### breaking changes
+
+* STRINGPARSER Type no longer will Use Scale/shift values.
 
 # v 0.7.7 (2018-05-28)
 ### New Features

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ If you want to build a package yourself, or contribute. Here is a guide for how 
 
 ### Dependencies
 
-- Go 1.5
+- Go 1.5 for snmpcollector < 0.8
+- Go 1.11 for snmpcollector >= 0.8
 - NodeJS >=6.2.1
 
 ### Get Code

--- a/pkg/config/snmpmetriccfg.go
+++ b/pkg/config/snmpmetriccfg.go
@@ -238,8 +238,8 @@ func (m *SnmpMetricCfg) GetValidConversions() ([]ConversionMode, ConversionMode,
 		return []ConversionMode{STRING}, STRING, nil
 	case "ENUM": //no conversion  neeeded (not triggered)
 		return []ConversionMode{STRING}, STRING, nil
-	case "OCTETSTRING": //no conversion  neeeded (not triggered)
-		return []ConversionMode{STRING}, STRING, nil
+	case "OCTETSTRING": //no conversion  needed (not triggered)
+		return []ConversionMode{STRING, INTEGER}, STRING, nil
 	case "OID": //no conversion  neeeded (not triggered)
 		return []ConversionMode{STRING}, STRING, nil
 	case "HWADDR", "IpAddress": //no conversion  neeeded (not triggered)

--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -56,6 +56,7 @@ type SnmpMetric struct {
 	ElapsedTime float64
 	Compute     func(arg ...interface{})                `json:"-"`
 	Scale       func()                                  `json:"-"`
+	Convert     func()                                  `json:"-"`
 	SetRawData  func(pdu gosnmp.SnmpPDU, now time.Time) `json:"-"`
 	RealOID     string
 	Report      int //if false this metric won't be sent to the output buffer (is just taken as a coomputed input for other metrics)
@@ -108,6 +109,82 @@ func (s *SnmpMetric) SetLogger(l *logrus.Logger) {
 	s.log = l
 }
 
+// Conversion functions
+
+func (s *SnmpMetric) convertFromInteger() {
+	//the only acceptable conversions
+	// signed integer 64 -> float64
+	switch s.cfg.Conversion {
+	case config.INTEGER:
+		return
+	case config.FLOAT:
+		s.CookedValue = float64(s.CookedValue.(int64))
+	default:
+		s.log.Errorf("Bad conversion: requested %s from %T type", s.cfg.Conversion.GetString(), s.CookedValue)
+	}
+}
+
+func (s *SnmpMetric) convertFromFloat() {
+	//the only acceptable conversions
+	// signed float -> int64 (will do rounded value)
+	switch s.cfg.Conversion {
+	case config.INTEGER:
+		s.CookedValue = int64(math.Round(s.CookedValue.(float64)))
+	case config.FLOAT:
+		return
+	default:
+		s.log.Errorf("Bad conversion: requested %s from %T type", s.cfg.Conversion.GetString(), s.CookedValue)
+	}
+}
+
+func (s *SnmpMetric) convertFromString() {
+	//the only acceptable conversions
+	// string -> int64
+	// string -> float (the default)
+	// string -> boolean
+	// string -> string
+	switch s.cfg.Conversion {
+	case config.STRING:
+		return
+	case config.INTEGER:
+		value, err := strconv.ParseInt(s.CookedValue.(string), 10, 64)
+		if err != nil {
+			s.log.Warnf("Error parsing Integer from String  %s metric %s : error: %s", s.CookedValue.(string), s.cfg.ID, err)
+			return
+		}
+		s.CookedValue = value
+	case config.FLOAT:
+		value, err := strconv.ParseFloat(s.CookedValue.(string), 64)
+		if err != nil {
+			s.log.Warnf("Error parsing float from String  %s metric %s : error: %s", s.CookedValue.(string), s.cfg.ID, err)
+			return
+		}
+		s.CookedValue = value
+	case config.BOOLEAN:
+		value, err := strconv.ParseBool(s.CookedValue.(string))
+		if err != nil {
+			s.log.Warnf("Error parsing Boolean from String  %s metric %s : error: %s", s.CookedValue.(string), s.cfg.ID, err)
+			return
+		}
+		s.CookedValue = value
+	default:
+		s.log.Errorf("Bad conversion: requested %s from %T type", s.cfg.Conversion.GetString(), s.CookedValue)
+	}
+}
+
+func (s *SnmpMetric) convertFromAny() {
+	switch s.CookedValue.(type) {
+	case float32, float64:
+		s.convertFromFloat()
+	case uint64, uint32, int64, int32: //review uint vs int
+		s.convertFromInteger()
+	case string:
+		s.convertFromString()
+	case bool:
+	default:
+	}
+}
+
 // Init Initialice a new snmpmetric object with the specific configuration
 func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 	if c == nil {
@@ -115,6 +192,8 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 	}
 	s.cfg = c
 	s.RealOID = c.BaseOID
+	//set default conversion funcion
+	s.Convert = s.convertFromAny
 	if s.cfg.Scale != 0.0 || s.cfg.Shift != 0.0 {
 		s.Scale = func() {
 			s.CookedValue = (s.cfg.Scale * float64(s.CookedValue.(float64))) + s.cfg.Shift
@@ -148,8 +227,10 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 	case "TIMETICKS": //Cooked TimeTicks
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
 			val := snmp.PduVal2Int64(pdu)
-			s.CookedValue = float64(val / 100) //now data in secoonds
+			//s.CookedValue = float64(val / 100) //now data in secoonds
+			s.CookedValue = val / 100 //now data in secoonds
 			s.CurTime = now
+			s.convertFromInteger()
 			s.Scale()
 			s.Valid = true
 		}
@@ -157,18 +238,22 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 		//Signed Integers
 	case "INTEGER", "Integer32":
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
-			val := snmp.PduVal2Int64(pdu)
-			s.CookedValue = float64(val)
+			//val := snmp.PduVal2Int64(pdu)
+			//s.CookedValue = float64(val)
+			s.CookedValue = snmp.PduVal2Int64(pdu)
 			s.CurTime = now
+			s.convertFromInteger()
 			s.Scale()
 			s.Valid = true
 		}
 		//Unsigned Integers
 	case "Counter32", "Gauge32", "Counter64", "TimeTicks", "UInteger32", "Unsigned32":
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
-			val := snmp.PduVal2UInt64(pdu)
-			s.CookedValue = float64(val)
+			//val := snmp.PduVal2UInt64(pdu)
+			//s.CookedValue = float64(val)
+			s.CookedValue = snmp.PduVal2UInt64(pdu)
 			s.CurTime = now
+			s.convertFromInteger()
 			s.Scale()
 			s.Valid = true
 		}
@@ -186,6 +271,7 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				s.CurValue = val
 				s.CurTime = now
 				s.Compute()
+				s.Convert()
 				s.Scale()
 				s.Valid = true
 			}
@@ -199,15 +285,19 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 					s.CookedValue = float64(s.CurValue.(uint64)-s.LastValue.(uint64)) / s.ElapsedTime
 				}
 			}
+			s.Convert = s.convertFromFloat
 		} else {
 			s.Compute = func(arg ...interface{}) {
 				s.ElapsedTime = s.CurTime.Sub(s.LastTime).Seconds()
 				if s.CurValue.(uint64) < s.LastValue.(uint64) {
-					s.CookedValue = float64(math.MaxUint32 - s.LastValue.(uint64) + s.CurValue.(uint64))
+					//s.CookedValue = float64(math.MaxUint32 - s.LastValue.(uint64) + s.CurValue.(uint64))
+					s.CookedValue = math.MaxUint32 - s.LastValue.(uint64) + s.CurValue.(uint64)
 				} else {
-					s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
+					//s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
+					s.CookedValue = s.CurValue.(uint64) - s.LastValue.(uint64)
 				}
 			}
+			s.Convert = s.convertFromInteger
 		}
 	case "COUNTER64": //Increment computed
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
@@ -225,6 +315,7 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				s.CurValue = val
 				s.CurTime = now
 				s.Compute()
+				s.Convert()
 				s.Scale()
 				s.Valid = true
 			}
@@ -232,23 +323,25 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 		if s.cfg.GetRate == true {
 			s.Compute = func(arg ...interface{}) {
 				s.ElapsedTime = s.CurTime.Sub(s.LastTime).Seconds()
-				//duration := s.CurTime.Sub(s.LastTime)
 				if s.CurValue.(uint64) < s.LastValue.(uint64) {
 					s.CookedValue = float64(math.MaxUint64-s.LastValue.(uint64)+s.CurValue.(uint64)) / s.ElapsedTime
 				} else {
 					s.CookedValue = float64(s.CurValue.(uint64)-s.LastValue.(uint64)) / s.ElapsedTime
 				}
 			}
+			s.Convert = s.convertFromFloat
 		} else {
 			s.Compute = func(arg ...interface{}) {
 				s.ElapsedTime = s.CurTime.Sub(s.LastTime).Seconds()
 				if s.CurValue.(uint64) < s.LastValue.(uint64) {
-					s.CookedValue = float64(math.MaxUint64 - s.LastValue.(uint64) + s.CurValue.(uint64))
+					//s.CookedValue = float64(math.MaxUint64 - s.LastValue.(uint64) + s.CurValue.(uint64))
+					s.CookedValue = math.MaxUint64 - s.LastValue.(uint64) + s.CurValue.(uint64)
 				} else {
-					s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
+					//s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
+					s.CookedValue = s.CurValue.(uint64) - s.LastValue.(uint64)
 				}
 			}
-
+			s.Convert = s.convertFromInteger
 		}
 	case "COUNTERXX": //Generic Counter With Unknown range or buggy counters that  Like Non negative derivative
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
@@ -264,6 +357,7 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				s.CurValue = val
 				s.CurTime = now
 				s.Compute()
+				s.Convert()
 				s.Valid = true
 			}
 		}
@@ -272,27 +366,28 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				s.ElapsedTime = s.CurTime.Sub(s.LastTime).Seconds()
 				if s.CurValue.(uint64) >= s.LastValue.(uint64) {
 					s.CookedValue = float64(s.CurValue.(uint64)-s.LastValue.(uint64)) / s.ElapsedTime
-					if s.cfg.Scale != 0.0 || s.cfg.Shift != 0.0 {
-						s.CookedValue = (s.cfg.Scale * float64(s.CookedValue.(float64))) + s.cfg.Shift
-					}
+					s.Convert()
+					s.Scale()
 				} else {
 					// Else => nothing to do last value will be sent
 					s.log.Warnf("Warning Negative COUNTER increment [current: %d | last: %d ] last value will be sent %f", s.CurValue, s.LastValue, s.CookedValue)
 				}
 			}
+			s.Convert = s.convertFromFloat
 		} else {
 			s.Compute = func(arg ...interface{}) {
 				s.ElapsedTime = s.CurTime.Sub(s.LastTime).Seconds()
 				if s.CurValue.(uint64) >= s.LastValue.(uint64) {
-					s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
-					if s.cfg.Scale != 0.0 || s.cfg.Shift != 0.0 {
-						s.CookedValue = (s.cfg.Scale * float64(s.CookedValue.(float64))) + s.cfg.Shift
-					}
+					//s.CookedValue = float64(s.CurValue.(uint64) - s.LastValue.(uint64))
+					s.CookedValue = s.CurValue.(uint64) - s.LastValue.(uint64)
+					s.Convert()
+					s.Scale()
 				} else {
 					// Else => nothing to do last value will be sent
 					s.log.Warnf("Warning Negative COUNTER increment [current: %d | last: %d ] last value will be sent %f", s.CurValue, s.LastValue, s.CookedValue)
 				}
 			}
+			s.Convert = s.convertFromInteger
 		}
 	case "BITS":
 		s.SetRawData = func(pdu gosnmp.SnmpPDU, now time.Time) {
@@ -318,7 +413,7 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 			} else {
 				s.CookedValue = 0.0
 			}
-
+			s.Convert()
 			s.CurTime = now
 			s.Valid = true
 			s.log.Debugf("BITS CHECK bit %+v, Position %d , RESULT %t", barray, index, s.CookedValue)
@@ -378,14 +473,16 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				s.log.Warnf("Error for metric [%s] parsing REGEXG [%s] on string [%s] cause  void capturing group", s.cfg.ID, s.cfg.ExtraData, str)
 				return
 			}
-			value, err := strconv.ParseFloat(retarray[1], 64)
+			/*value, err := strconv.ParseFloat(retarray[1], 64)
 			if err != nil {
 				s.log.Warnf("Error parsing float for metric %s : error: %s", s.cfg.ID, err)
 				return
 			}
-			s.CookedValue = value
+			s.CookedValue = value*/
+			s.CookedValue = retarray[1]
 			s.CurTime = now
-			s.Scale()
+			s.convertFromString()
+			//s.Scale() <-only valid if Integuer or String
 			s.Valid = true
 		}
 	case "MULTISTRINGPARSER":
@@ -436,7 +533,9 @@ func (s *SnmpMetric) Init(c *config.SnmpMetricCfg) error {
 				}
 			}
 			s.CookedValue = result
+			//conversion depends onthe type of the evaluted data.
 			s.CurTime = time.Now()
+			s.Convert()
 			s.Scale()
 			s.Valid = true
 		}

--- a/pkg/data/snmp/snmp.go
+++ b/pkg/data/snmp/snmp.go
@@ -336,6 +336,16 @@ func PduVal2str(pdu gosnmp.SnmpPDU) string {
 	return ""
 }
 
+// PduValHexString2Uint transform PDU HexString to uint64
+func PduValHexString2Uint(pdu gosnmp.SnmpPDU) (uint64, error) {
+	value := pdu.Value
+	if pdu.Type == gosnmp.OctetString {
+		result, err := strconv.ParseUint(string(value.([]byte)), 16, 64)
+		return result, err
+	}
+	return 0, fmt.Errorf("The PDU scanned is not and OctecString as expected")
+}
+
 // PduVal2OID transform PDU data to string
 func PduVal2OID(pdu gosnmp.SnmpPDU) string {
 	value := pdu.Value

--- a/pkg/webui/apicfg-snmpmetric.go
+++ b/pkg/webui/apicfg-snmpmetric.go
@@ -19,6 +19,7 @@ func NewAPICfgSnmpMetric(m *macaron.Macaron) error {
 		m.Delete("/:id", reqSignedIn, DeleteMetric)
 		m.Get("/:id", reqSignedIn, GetMetricByID)
 		m.Get("/checkondel/:id", reqSignedIn, GetMetricsAffectOnDel)
+		m.Post("/convmodes", reqSignedIn, bind(config.SnmpMetricCfg{}), GetConversionModes)
 	})
 
 	return nil
@@ -98,4 +99,26 @@ func GetMetricsAffectOnDel(ctx *Context) {
 	} else {
 		ctx.JSON(200, &obarray)
 	}
+}
+
+type ConversionItem struct {
+	ID      int
+	Value   string
+	Default bool
+}
+
+// GetConversionModes Return conversion modes from datasource Type
+func GetConversionModes(ctx *Context, dev config.SnmpMetricCfg) {
+	var response []ConversionItem
+	cfgarray, def, err := dev.GetValidConversions()
+	if err != nil {
+		ctx.JSON(404, err.Error())
+		log.Errorf("Error on get  Conversion Mode :%s", err)
+		return
+	}
+	for k, v := range cfgarray {
+		response = append(response, ConversionItem{ID: int(v), Value: v.GetString(), Default: (k == def)})
+	}
+	ctx.JSON(200, &response)
+	log.Debugf("Got Conversion Items Array Metrics %+v", &response)
 }

--- a/pkg/webui/apicfg-snmpmetric.go
+++ b/pkg/webui/apicfg-snmpmetric.go
@@ -101,24 +101,31 @@ func GetMetricsAffectOnDel(ctx *Context) {
 	}
 }
 
+// Conversion Item for selection
 type ConversionItem struct {
-	ID      int
-	Value   string
-	Default bool
+	ID    int
+	Value string
+}
+
+// ConversionItems array with all items and default/suggested value for this metric
+type ConversionItems struct {
+	Default int
+	Items   []ConversionItem
 }
 
 // GetConversionModes Return conversion modes from datasource Type
 func GetConversionModes(ctx *Context, dev config.SnmpMetricCfg) {
-	var response []ConversionItem
+	var citem []ConversionItem
 	cfgarray, def, err := dev.GetValidConversions()
 	if err != nil {
 		ctx.JSON(404, err.Error())
 		log.Errorf("Error on get  Conversion Mode :%s", err)
 		return
 	}
-	for k, v := range cfgarray {
-		response = append(response, ConversionItem{ID: int(v), Value: v.GetString(), Default: (k == def)})
+	for _, v := range cfgarray {
+		citem = append(citem, ConversionItem{ID: int(v), Value: v.GetString()})
 	}
-	ctx.JSON(200, &response)
-	log.Debugf("Got Conversion Items Array Metrics %+v", &response)
+	response := &ConversionItems{Default: int(def), Items: citem}
+	ctx.JSON(200, response)
+	log.Debugf("Got Conversion Items Array Metrics %+v", response)
 }

--- a/src/snmpmetric/snmpmetriccfg.component.ts
+++ b/src/snmpmetric/snmpmetriccfg.component.ts
@@ -129,8 +129,10 @@ export class SnmpMetricCfgComponent {
     }
     this.snmpMetricService.getConversionModes(value)
     .subscribe(data => {
-      this.conversionModes = data;
-      console.log(this.conversionModes)
+      this.conversionModes = data.Items;
+      console.log("ITEMS:",data.Items)
+      this.snmpmetForm.value['Conversion'] = data.Default;
+      console.log("CONVERSION:",this.conversionModes)
       },
       err => console.error(err)
     );

--- a/src/snmpmetric/snmpmetriccfg.component.ts
+++ b/src/snmpmetric/snmpmetriccfg.component.ts
@@ -38,6 +38,7 @@ export class SnmpMetricCfgComponent {
   public isRequesting : boolean;
   public counterItems : number = null;
   public counterErrors: any = [];
+  public conversionModes: Array<any>;
 
   itemsPerPageOptions : any = ItemsPerPageOptions;
   editmode: string; //list , create, modify
@@ -87,7 +88,8 @@ export class SnmpMetricCfgComponent {
       ID: [this.snmpmetForm ? this.snmpmetForm.value.ID : '', Validators.required],
       FieldName: [this.snmpmetForm ? this.snmpmetForm.value.FieldName : '', Validators.required],
       DataSrcType: [this.snmpmetForm ? this.snmpmetForm.value.DataSrcType : 'Gauge32', Validators.required],
-      Description: [this.snmpmetForm ? this.snmpmetForm.value.Description : '']
+      Description: [this.snmpmetForm ? this.snmpmetForm.value.Description : ''],
+      Conversion: [this.snmpmetForm ? this.snmpmetForm.value.Conversion : 0]
     });
   }
 
@@ -114,6 +116,25 @@ export class SnmpMetricCfgComponent {
   setDynamicFields (field : any, override? : boolean) : void  {
     //Saves on the array all values to push into formGroup
     let controlArray : Array<any> = [];
+    let value : any;
+
+    if (this.snmpmetForm ) {
+      //need a clone of the object 
+      value = { ...this.snmpmetForm.value}
+      //force required fields to be not null to get Conversion modes on the cloned object
+      value['ID']='test'
+      value['FieldName']='test'
+    } else {
+      value = { ID: 'test', FieldName: 'test', DataSrcType: 'Gauge32' };
+    }
+    this.snmpMetricService.getConversionModes(value)
+    .subscribe(data => {
+      this.conversionModes = data;
+      console.log(this.conversionModes)
+      },
+      err => console.error(err)
+    );
+ 
 
     switch (field) {
       case 'BITS':
@@ -126,11 +147,13 @@ export class SnmpMetricCfgComponent {
       case 'IpAddress':
         controlArray.push({'ID': 'BaseOID', 'defVal' : '', 'Validators' : Validators.compose([ValidationService.OIDValidator, Validators.required]) })
         controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });
+        controlArray.push({'ID': 'Conversion', 'defVal' : 3, 'Validators' : Validators.required, 'override' : override })
         break;
       case 'CONDITIONEVAL':
         this.getOidCond();
         controlArray.push({'ID': 'ExtraData', 'defVal' : '', 'Validators' : Validators.required, 'override' : override });
-        controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });
+        controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });        
+        controlArray.push({'ID': 'Conversion', 'defVal' : 1, 'Validators' : Validators.required, 'override' : override })
         break;
       case 'STRINGPARSER':
         controlArray.push({'ID': 'BaseOID', 'defVal' : '', 'Validators' : Validators.compose([ValidationService.OIDValidator, Validators.required]) })
@@ -138,6 +161,7 @@ export class SnmpMetricCfgComponent {
         controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });
         controlArray.push({'ID': 'Scale', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
         controlArray.push({'ID': 'Shift', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
+        controlArray.push({'ID': 'Conversion', 'defVal' : 0, 'Validators' : Validators.required, 'override' : override })
         break;
       case 'MULTISTRINGPARSER':
         controlArray.push({'ID': 'BaseOID', 'defVal' : '', 'Validators' : Validators.compose([ValidationService.OIDValidator, Validators.required]) })
@@ -148,6 +172,7 @@ export class SnmpMetricCfgComponent {
         controlArray.push({'ID': 'ExtraData', 'defVal' : '', 'Validators' : Validators.required, 'override' : override });
         controlArray.push({'ID': 'Scale', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
         controlArray.push({'ID': 'Shift', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
+        controlArray.push({'ID': 'Conversion', 'defVal' : 0, 'Validators' : Validators.required, 'override' : override })
         break;
       case 'COUNTER32':
       case 'COUNTER64':
@@ -159,6 +184,7 @@ export class SnmpMetricCfgComponent {
         controlArray.push({'ID': 'Scale', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
         controlArray.push({'ID': 'Shift', 'defVal' : '0', 'Validators' : Validators.compose([Validators.required, ValidationService.floatValidator]) })
         controlArray.push({'ID': 'IsTag', 'defVal' : 'false', 'Validators' : Validators.required, 'override' : override });
+        controlArray.push({'ID': 'Conversion', 'defVal' : 1, 'Validators' : Validators.required, 'override' : override })
         break;
     }
     //Reload the formGroup with new values saved on controlArray

--- a/src/snmpmetric/snmpmetriccfg.service.ts
+++ b/src/snmpmetric/snmpmetriccfg.service.ts
@@ -16,6 +16,9 @@ export class SnmpMetricService {
         key == 'Shift') {
             return parseFloat(value);
         };
+        if ( key == 'Conversion') {
+            return parseInt(value);
+        }
         if (key == 'GetRate' ||
         key == 'IsTag' ) return ( value === "true" || value === true);
         return value; 
@@ -66,6 +69,12 @@ export class SnmpMetricService {
         .map( (responseData) =>
             responseData.json()
     )};
+
+    getConversionModes(dev) {
+        console.log("DEV: ",dev);
+        return this.httpAPI.post('/api/cfg/metric/convmodes/',JSON.stringify(dev,this.parseJSON))
+        .map( (responseData) => responseData.json());
+    };
 
     checkOnDeleteMetric(id : string){
       return this.httpAPI.get('/api/cfg/metric/checkondel/'+id)

--- a/src/snmpmetric/snmpmetriceditor.html
+++ b/src/snmpmetric/snmpmetriceditor.html
@@ -123,20 +123,6 @@
         </div>
       </div>
 
-      <div class="form-group" *ngIf="snmpmetForm.controls.Conversion && snmpmetForm.value.DataSrcType != 'MULTISTRINGPARSER' ">
-        <label class="control-label col-sm-2" for="Conversion">Conversion</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Conversion mode "></i>
-        <div class="col-sm-9">
-          <select formControlName="Conversion" id="Conversion" [ngModel]="snmpmetForm.value.Conversion">
-              <option *ngFor='let controlList of conversionModes' [value]="controlList.ID">
-                {{controlList.Value}}
-              </option>
-          </select>
-          <!--input formControlName="Conversion" id="Conversion" [ngModel]="snmpmetForm.value.Conversion"/-->
-          <control-messages [control]="snmpmetForm.controls.Conversion"></control-messages>
-        </div>
-      </div>
-
       <div class="form-group" *ngIf="snmpmetForm.controls.GetRate">
         <label class="control-label col-sm-2" for="GetRate">GetRate</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Normalize the returned value by time"></i>
@@ -148,6 +134,20 @@
           <control-messages [control]="snmpmetForm.controls.GetRate"></control-messages>
         </div>
       </div>
+
+      <div class="form-group" *ngIf="snmpmetForm.controls.Conversion && snmpmetForm.value.DataSrcType != 'MULTISTRINGPARSER' ">
+          <label class="control-label col-sm-2" for="Conversion">Conversion</label>
+          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Conversion mode "></i>
+          <div class="col-sm-9">
+            <select formControlName="Conversion" id="Conversion" [ngModel]="snmpmetForm.value.Conversion">
+                <option *ngFor='let controlList of conversionModes' [value]="controlList.ID">
+                  {{controlList.Value}}
+                </option>
+            </select>
+            <control-messages [control]="snmpmetForm.controls.Conversion"></control-messages>
+          </div>
+        </div>
+
     </div>
     <div class="well well-sm" *ngIf="snmpmetForm.controls.Scale || snmpmetForm.controls.Shift">
       <span class="editsection">

--- a/src/snmpmetric/snmpmetriceditor.html
+++ b/src/snmpmetric/snmpmetriceditor.html
@@ -123,6 +123,20 @@
         </div>
       </div>
 
+      <div class="form-group" *ngIf="snmpmetForm.controls.Conversion && snmpmetForm.value.DataSrcType != 'MULTISTRINGPARSER' ">
+        <label class="control-label col-sm-2" for="Conversion">Conversion</label>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Conversion mode "></i>
+        <div class="col-sm-9">
+          <select formControlName="Conversion" id="Conversion" [ngModel]="snmpmetForm.value.Conversion">
+              <option *ngFor='let controlList of conversionModes' [value]="controlList.ID">
+                {{controlList.Value}}
+              </option>
+          </select>
+          <!--input formControlName="Conversion" id="Conversion" [ngModel]="snmpmetForm.value.Conversion"/-->
+          <control-messages [control]="snmpmetForm.controls.Conversion"></control-messages>
+        </div>
+      </div>
+
       <div class="form-group" *ngIf="snmpmetForm.controls.GetRate">
         <label class="control-label col-sm-2" for="GetRate">GetRate</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Normalize the returned value by time"></i>
@@ -135,10 +149,10 @@
         </div>
       </div>
     </div>
-      <div class="well well-sm" *ngIf="snmpmetForm.controls.Scale || snmpmetForm.controls.Shift">
-          <span class="editsection">
-            Metric Autoscale
-          </span>
+    <div class="well well-sm" *ngIf="snmpmetForm.controls.Scale || snmpmetForm.controls.Shift">
+      <span class="editsection">
+        Metric Autoscale
+      </span>
       <div class="form-group" style="margin-top: 25px" *ngIf="snmpmetForm.controls.Scale">
         <label class="control-label col-sm-2" for="Scale">Scale</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Scale the returned value by a num"></i>
@@ -157,10 +171,10 @@
         </div>
       </div>
     </div>
-          <div class="well well-sm">
-            <span class="editsection">
-              Extra Settings
-            </span>
+    <div class="well well-sm">
+      <span class="editsection">
+        Extra Settings
+      </span>
       <div class="form-group" style="margin-top: 25px">
         <label class="control-label col-sm-2" for="Description">Description</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the SNMP Metric"></i>


### PR DESCRIPTION
Until 0.7.6 Snmpcollector send data to its influxDB backend only as floating point numbers ( except on MULTI STRING PARSER where you can choose the final type for each part) 
Now with this PR snmpcollector will have ability to make type some kind of data conversion once the data has been gathered /  computed , for all types ( depending of course on the datasource type) 