### PR TITLE
agent mutex related bugfixes

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -131,10 +131,10 @@ func GetDevice(id string) (*device.SnmpDevice, error) {
 		return nil, fmt.Errorf("There is a reload process running.... please wait until finished ")
 	}
 	mutex.RLock()
+	defer mutex.RUnlock()
 	if dev, ok = devices[id]; !ok {
 		return nil, fmt.Errorf("there is not any device with id %s running", id)
 	}
-	mutex.RUnlock()
 	return dev, nil
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -78,8 +78,8 @@ func SetLogger(l *logrus.Logger) {
 
 // CheckReloadProcess check if the agent is doing a reloading just now
 func CheckReloadProcess() bool {
-	reloadMutex.Lock()
-	defer reloadMutex.Unlock()
+	reloadMutex.RLock()
+	defer reloadMutex.RUnlock()
 	return reloadProcess
 }
 


### PR DESCRIPTION
Two bugfixes in agent mutex handling:

- Use read lock in `CheckReloadProcess()` to check the reload status
- Release `mutex` on error in `GetDevice()` 