### PR TITLE
Added Multi Index and Indexed with multi indirect tag measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@
 * Added Mock SnmpServer and measurements unit tests
 * Added [trim](https://github.com/toni-moreno/snmpcollector/wiki/Component:-SNMP-Metrics#about-octetstringhex-string) functions in octetstring based metrics (#405)
 * added HTTPS support 
+* Added new measurement types: multi-index and indirect multi tag to retrieve complex MIBs like [QoS](https://github.com/toni-moreno/snmpcollector/wiki/Example:-Cisco-QoS)
 
 ### fixes
 * Fixed  #446
 * Fixed  #405
+* Fixed  #398
 
 ### breaking changes
-
+* Measurement TagName property (only retrieved on runtime API) changed from `string` to `[]string`
 
 # v 0.8.1 ( 2020-10-06 ) 
 ### New Features

--- a/pkg/data/measurement/formatmultiindex.go
+++ b/pkg/data/measurement/formatmultiindex.go
@@ -1,0 +1,320 @@
+package measurement
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MultiIndexFormat defines the required fields to build multiindex result
+type MultiIndexFormat struct {
+	Label            string
+	CurIndexedLabels map[string]string
+	TagName          []string
+	Index            int
+	DepDesc          string
+	Dependency       *MultiIndexDependency
+}
+
+// MultiIndexDependency defines the dependency pararams required to build mulitindex result
+type MultiIndexDependency struct {
+	Index    int
+	Start    int
+	End      int
+	Strategy []string
+}
+
+// GetDepMultiParams - Parse Dependency description and creates a new MultiIndexDependency object
+func (mi *MultiIndexFormat) GetDepMultiParams() error {
+
+	// Dependency syntax follows as:
+	// IDX{M}[];DOT[START:END];FILL(XXX)]
+	// To simplify its logic, it can be defined also as IDX{M}
+	mdep := MultiIndexDependency{}
+
+	// Read dependency params splitted by ';'
+	dep := strings.Split(mi.DepDesc, ";")
+
+	if len(dep) < 1 {
+		return fmt.Errorf("Invalid dependency description %s", mi.DepDesc)
+	}
+
+	// Index dependency - dep[0]
+	pattern := "IDX{([0-9]+)}"
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	match := re.FindStringSubmatch(dep[0])
+	if len(match) < 1 {
+		return fmt.Errorf("Couldn't find any matching dependency on %+v", dep[0])
+	}
+
+	// ensure its a valid number and its
+	ndep, err := strconv.Atoi(match[1])
+	if err != nil {
+		return err
+	}
+	mdep.Index = ndep
+
+	// If only dependency is provided, just load it as defaults and return
+	if len(dep) == 1 {
+		mdep.Start = -1
+		mdep.End = -1
+		mdep.Strategy = []string{"", ""}
+		mi.Dependency = &mdep
+		return nil
+	}
+
+	// Check if DOT and Strategy are provided...
+	if len(dep) == 3 {
+
+		// dep[1] - Index Position
+		ipattern, err := regexp.Compile("DOT\\[(\\d*):(\\d*)\\]")
+		if err != nil {
+			return err
+		}
+
+		imatch := ipattern.FindStringSubmatch(dep[1])
+		if len(imatch) < 3 {
+			return fmt.Errorf("Couldn't find index matching on %+v", dep[1])
+		}
+		dotInit := imatch[1]
+		dotEnd := imatch[2]
+
+		first, err := strconv.Atoi(dotInit) // if there is an error first will be 0
+		if err != nil {
+			return err
+		}
+		last, err := strconv.Atoi(dotEnd) // if there is an error last
+		if err != nil {
+			last = -1
+			//Not sure if needs to return an error...
+			return err
+		}
+		mdep.Start = first
+		mdep.End = last
+
+		// ************ PARSE FILL STRATEGY **************************
+
+		fpattern, err := regexp.Compile("(\\w+)(?:\\((.*)\\))?")
+		if err != nil {
+			return err
+		}
+
+		fmatch := fpattern.FindStringSubmatch(dep[2])
+		if len(fmatch) < 1 {
+			return fmt.Errorf("Error trying to parse dependency strategy %v", fmatch)
+		}
+		//finally, store the result...
+		mdep.Strategy = fmatch
+
+		mi.Dependency = &mdep
+		return nil
+	}
+	return fmt.Errorf("Missing dependency variable %s", mi.DepDesc)
+
+}
+
+// MultiIndexFormatArray - type to implement Sort interface and allow order by dependency
+type MultiIndexFormatArray []*MultiIndexFormat
+
+// Len - Sort interface function to return len of array
+func (mif MultiIndexFormatArray) Len() int {
+	return len(mif)
+}
+
+// Less - Sort interface function to add logic on sort function
+func (mif MultiIndexFormatArray) Less(i, j int) bool {
+
+	//Retrieve if there are dependencies and retrieve the index of each one...
+	idxi := -1
+	idxj := -1
+
+	if mif[j].Dependency != nil {
+		idxj = mif[j].Dependency.Index
+	}
+	if mif[i].Dependency != nil {
+		idxi = mif[i].Dependency.Index
+	}
+
+	return idxi < idxj
+}
+
+// Swap - Sort interface function to swap elements between array
+func (mif MultiIndexFormatArray) Swap(i, j int) {
+	mif[i], mif[j] = mif[j], mif[i]
+}
+
+// GetDepIndex - Return the real index of the array based on dependency. Needed as array is sorted
+func (mif MultiIndexFormatArray) GetDepIndex(ri int) (int, error) {
+	for i, mi := range mif {
+		if mi.Index == ri {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("Provided index in dependency not found %d", ri)
+}
+
+// BuildParseResults - Build result array based on result string
+func BuildParseResults(allindex MultiIndexFormatArray, rs []string) (MultiIndexFormatArray, string, error) {
+
+	//combpattern := `^([0-9]+)$|^(IDX\{([0-9])\})$`
+	combpattern := `^([0-9]+)$|^(IDX\{([0-9])\}(?:;(DOT\[\d*:\d*\]))?)$`
+	re, err := regexp.Compile(combpattern)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// The strategy follows as:
+	// find all index splitted by '.' until an IDX{X} is found.
+	// all index is stored as index and loaded as index on IDX{X}
+	// in case that a prefix is found and it matches with the last dot
+	// it is stored on suffix and will be loaded into the last merged tables
+	var prefix string
+	var suffix string
+	var resindex MultiIndexFormatArray
+
+	for i, v := range rs {
+		// we need to check if v is a simple number or an expression (using regex?)
+		match := re.FindStringSubmatch(v)
+		//fmt.Println(match, len(match))
+		if len(match) == 0 {
+			return nil, "", fmt.Errorf("Invalid value provided on mulitindex result %s", v)
+		}
+		//Case number is retrieved
+		if match[1] != "" {
+			if prefix != "" {
+				prefix += "."
+			}
+			prefix += v
+			if i == len(rs)-1 {
+				suffix += prefix
+			}
+		}
+		//Case IDX{M} is retrieved
+		if match[2] != "" {
+			ndep, err := strconv.Atoi(match[3])
+			if err != nil {
+				return nil, "", fmt.Errorf("Invalid provided result index. Error: %s", err)
+			}
+
+			ir, err := allindex.GetDepIndex(ndep)
+			if err != nil {
+				return nil, "", err
+			}
+
+			mi := MultiIndexFormat{
+				TagName:          allindex[ir].TagName,
+				Index:            allindex[ir].Index,
+				DepDesc:          allindex[ir].DepDesc,
+				Dependency:       allindex[ir].Dependency,
+				CurIndexedLabels: make(map[string]string),
+			}
+			//Deep copy if CurIndexedLabels, index can be reused...
+			// Case DOT is provided...
+			var first, last int
+			var sapply bool
+			if match[4] != "" {
+				// dep[1] - Index Position
+				ipattern, err := regexp.Compile("DOT\\[(\\d*):(\\d*)\\]")
+				if err != nil {
+					return nil, "", err
+				}
+
+				imatch := ipattern.FindStringSubmatch(match[4])
+				if len(imatch) < 3 {
+					return nil, "", fmt.Errorf("Couldn't find index matching on %+v", match[4])
+				}
+				dotInit := imatch[1]
+				dotEnd := imatch[2]
+
+				first, err = strconv.Atoi(dotInit) // if there is an error first will be 0
+				if err != nil {
+					return nil, "", err
+				}
+				last, err = strconv.Atoi(dotEnd) // if there is an error last
+				if err != nil {
+					last = -1
+					//Not sure if needs to return an error...
+					return nil, "", err
+				}
+				sapply = true
+			}
+			for k, v := range allindex[ir].CurIndexedLabels {
+				section := k
+				if sapply {
+					section, err = sectionDotSlice(k, first, last)
+					if err != nil {
+						return nil, "", err
+					}
+				}
+				mi.CurIndexedLabels[section] = v
+			}
+			//mi := allindex[ir]
+			kk := make(map[string]string)
+
+			// if there is some prefix, we need to append to the existing map, if not, it will directly be the currend indexes labels
+			if len(prefix) > 0 {
+				for k, v := range mi.CurIndexedLabels {
+					kk[prefix+"."+k] = v
+				}
+				mi.CurIndexedLabels = kk
+			}
+			resindex = append(resindex, &mi)
+			prefix = ""
+		}
+
+	}
+	return resindex, suffix, nil
+}
+
+// MergeResults - Merge all results
+func MergeResults(resindex MultiIndexFormatArray, suffix string) (*MultiIndexFormat, error) {
+
+	if len(resindex) == 0 {
+		return &MultiIndexFormat{}, fmt.Errorf("Empty result index after parsed all indexes")
+	}
+
+	//Start iteration to over all indexes and it will recursively store results on mi
+	mi := resindex[0]
+	for i := 1; i < len(resindex); i++ {
+		mi = MergeIndex(mi, resindex[i])
+	}
+
+	//Finally, check if we must apply some suffix...
+	if len(suffix) > 0 {
+		mi = AddSuffix(suffix, mi)
+	}
+
+	return mi, nil
+}
+
+// MergeIndex - Merges two tables by scalar product between indexes
+func MergeIndex(tmp, input *MultiIndexFormat) *MultiIndexFormat {
+
+	var pp MultiIndexFormat
+	pp.CurIndexedLabels = make(map[string]string)
+
+	for k, v := range tmp.CurIndexedLabels {
+		for kk, vv := range input.CurIndexedLabels {
+			pp.CurIndexedLabels[k+"."+kk] = v + "|" + vv
+		}
+	}
+
+	pp.TagName = append(pp.TagName, tmp.TagName...)
+	pp.TagName = append(pp.TagName, input.TagName...)
+	return &pp
+}
+
+// AddSuffix - Add suffix to existing index/label map
+func AddSuffix(suffix string, input *MultiIndexFormat) *MultiIndexFormat {
+	var pp MultiIndexFormat
+	pp.CurIndexedLabels = make(map[string]string)
+	for k, v := range input.CurIndexedLabels {
+		pp.CurIndexedLabels[k+"."+suffix] = v
+	}
+	pp.TagName = input.TagName
+	return &pp
+}

--- a/pkg/data/measurement/measurement.go
+++ b/pkg/data/measurement/measurement.go
@@ -2,8 +2,9 @@ package measurement
 
 import (
 	"fmt"
-
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -37,7 +38,7 @@ type Measurement struct {
 	cfg              *config.MeasurementCfg
 	ID               string
 	MName            string
-	TagName          string
+	TagName          []string
 	MetricTable      *MetricTable
 	snmpOids         []string
 	OidSnmpMap       map[string]*metric.SnmpMetric `json:"-"` //snmpMetric mapped with real OID's
@@ -53,6 +54,7 @@ type Measurement struct {
 	DisableBulk      bool                                `json:"-"`
 	GetData          func() (int64, int64, int64, error) `json:"-"`
 	Walk             func(string, gosnmp.WalkFunc) error `json:"-"`
+	MultiIndexMeas   []*Measurement
 }
 
 //New  creates object with config , log + goSnmp client
@@ -82,6 +84,7 @@ func (m *Measurement) Init() error {
 		m.GetData = m.SnmpWalkData
 	}
 
+	// If GetMode is multiindex, we can reuse a simple measurement to init each one and get all funcions...?
 	switch {
 	case m.snmpClient.Version == gosnmp.Version1 || m.DisableBulk:
 		m.Walk = m.snmpClient.Walk
@@ -89,10 +92,24 @@ func (m *Measurement) Init() error {
 		m.Walk = m.snmpClient.BulkWalk
 	}
 
+	if m.cfg.GetMode == "indexed_multiple" {
+		// Create, init and store the var into base measurement
+		err := m.InitMultiIndex()
+		if err != nil {
+			return err
+		}
+		// Load all dependencies and load base measurement
+		err = m.LoadMultiIndex()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	//loading all posible values in 	m.AllIndexedLabels
-	if m.cfg.GetMode == "indexed" || m.cfg.GetMode == "indexed_it" {
+	if m.cfg.GetMode == "indexed" || m.cfg.GetMode == "indexed_it" || m.cfg.GetMode == "indexed_mit" {
 		m.idxPosInOID = len(m.cfg.IndexOID)
-		m.TagName = m.cfg.IndexTag
+		m.TagName = append([]string{}, m.cfg.IndexTag)
 		if (m.cfg.GetMode) == "indexed_it" {
 			m.idx2PosInOID = len(m.cfg.TagOID)
 		}
@@ -113,6 +130,228 @@ func (m *Measurement) Init() error {
 	 * ******************************/
 	m.Debug("Initialize OID measurement per label => map of metric object per field | OID array [ready to send to the walk device] | OID=>Metric MAP")
 	m.MetricTable = NewMetricTable(m.cfg, m.log, m.CurIndexedLabels)
+	return nil
+}
+
+// InitMultiIndex initializes measurements from MultiIndexCfg
+func (m *Measurement) InitMultiIndex() error {
+
+	// Create an array of measurements, based on length of indexed_multiple:
+
+	multimeas := []*Measurement{}
+
+	// Go over all defined measuremens in MultiIndex...
+	for _, v := range m.cfg.MultiIndexCfg {
+		// Create a new measurement cfg from multiindex fields...
+		mcfg := config.MeasurementCfg{
+			ID:             m.ID + ".." + v.Label,
+			Name:           v.Label,
+			GetMode:        v.GetMode,
+			IndexOID:       v.IndexOID,
+			TagOID:         v.TagOID,
+			MultiTagOID:    v.MultiTagOID,
+			IndexTag:       v.IndexTag,
+			IndexTagFormat: v.IndexTagFormat,
+			Description:    v.Description,
+			Fields:         m.cfg.Fields,
+			FieldMetric:    m.cfg.FieldMetric,
+		}
+
+		//create entirely new measurement based on provided CFG
+		mm, err := New(&mcfg, m.log, m.snmpClient, m.DisableBulk)
+		if err != nil {
+			return err
+		}
+
+		//append it with order
+		multimeas = append(multimeas, mm)
+	}
+
+	// Save it in memory...
+	m.MultiIndexMeas = multimeas
+	return nil
+}
+
+// AddMultiFilter - initializes filter for each existin measurement defined in MultiIndexMeas
+func (m *Measurement) AddMultiFilter() {
+	for _, meas := range m.MultiIndexMeas {
+		meas.AddFilter(meas.FilterCfg, false)
+	}
+}
+
+// UpdateMultiFilter - updates filter for each existin measurement defined in MultiIndexMeas
+func (m *Measurement) UpdateMultiFilter() {
+	for _, meas := range m.MultiIndexMeas {
+		meas.UpdateFilter()
+	}
+}
+
+// BuildMultiIndexLabels - builds the multi index labels. Returns the CurIndexedLabels and TagName from processed result
+func (m *Measurement) BuildMultiIndexLabels() (map[string]string, []string, error) {
+
+	// Declare array of MultiIndexFormat
+	allindex := MultiIndexFormatArray{}
+
+	// Start deep copy of defined indexed measurements
+	for i, mindex := range m.MultiIndexMeas {
+		ci := make(map[string]string)
+		// as CurIndexedLabels is a map, need to make a safe copy of its value in new map
+		for i, k := range mindex.CurIndexedLabels {
+			ci[i] = k
+		}
+		iformat := &MultiIndexFormat{
+			CurIndexedLabels: ci,
+			TagName:          mindex.TagName,
+			Index:            i,
+			DepDesc:          m.cfg.MultiIndexCfg[i].Dependency,
+			Label:            mindex.ID,
+		}
+		if len(iformat.DepDesc) > 0 {
+			err := iformat.GetDepMultiParams()
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		allindex = append(allindex, iformat)
+	}
+
+	sort.Sort(MultiIndexFormatArray(allindex))
+
+	m.Debugf("Starting to process %d multiindex", len(allindex))
+
+	// Process dependencies | si: sort indexed | index: index info
+	for si, index := range allindex {
+		// Load on index Dependency all dependency params
+		m.Debugf("[%s] - GOT INDEX MULTIPARAMS --> %+v", index.Label, index.Dependency)
+
+		if index.Dependency != nil {
+			if index.Dependency.Index > len(allindex)-1 {
+				return nil, nil, fmt.Errorf("[%s] - Dependency is out of index range - %d [len: %d], read from %s", m.ID, index.Dependency.Index, len(allindex)-1, index.Label)
+			}
+			//Read the real id from dependency one, as it is orderered, it is guaranteed that it has already been processed
+			ri, err := allindex.GetDepIndex(index.Dependency.Index)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			//Check if the index is itself, just skip it
+			if si == ri {
+				m.Warnf("[%s] - Detected same IDX on dependency index, skipping it", index.Label)
+				continue
+			}
+
+			// Set CurIndexedLabels, ci: current index, cv: current value
+			for ci, cv := range index.CurIndexedLabels {
+				section := ci
+				if index.Dependency.Start != -1 {
+					section, err = sectionDotSlice(ci, index.Dependency.Start, index.Dependency.End)
+					if err != nil {
+						m.Warnf("[%] - SectionDotSlice Error: %s", index.Label, err)
+						return nil, nil, err
+					}
+				}
+				// check if section is found and split results by '|', dv : dependency value
+				if dv, ok := allindex[ri].CurIndexedLabels[section]; ok {
+					index.CurIndexedLabels[ci] = dv + "|" + cv
+				} else {
+					fill := ""
+					fillt := ""
+					switch index.Dependency.Strategy[1] {
+					case "SKIP":
+						delete(index.CurIndexedLabels, ci)
+					case "FILL":
+						if len(index.Dependency.Strategy) == 3 {
+							fillt = index.Dependency.Strategy[2]
+						}
+						fallthrough
+					default:
+						//fill need to be the number of retrieved tagNames
+						for i := 0; i < len(allindex[ri].TagName); i++ {
+							fill += fillt + "|"
+						}
+						index.CurIndexedLabels[ci] = fill + cv
+					}
+				}
+			}
+
+			// Set TagName
+			index.TagName = append(allindex[ri].TagName, index.TagName...)
+
+		} else {
+			m.Debugf("[%s] - has no dependency", index.Label)
+		}
+	}
+
+	// As the result is built with index, we can use a simply split(.) to mantain an array order
+	// Examples:
+	// s = strings.Split(m.cfg.MultiIndexResult ".")
+	// s = []string{"1", "2", "IDX{0}", "45", "IDX{1}", "4"}
+	// s = []string{"IDX{0}", "4", "IDX{1}", "5", "6"}
+	// s = []string{"IDX{0}"}
+
+	s := strings.Split(m.cfg.MultiIndexResult, ".")
+
+	resindex, suffix, err := BuildParseResults(allindex, s)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Start process of merge all generated IDX...
+	// Go over all indexes, start from the first and go over merging it
+	// Values will be stored as MultiIndexFormat, as it includes all indexes and tags...
+
+	// Exampple:
+	// [(1.1) = "TAG1A", (1.2) = "TAG1B"]
+	// [(2.1) = "TAG2A", (2.2) = "TAG2B"]
+
+	//RESULT:
+	// [(1.1.2.1)="TAG1A|TAG2A"]
+	// [(1.1.2.2)="TAG1A|TAG2B"]
+	// [(1.2.2.1)="TAG1B|TAG2A"]
+	// [(1.2.2.2)="TAG1B|TAG2B"]
+
+	// Exampple:
+	// [(1.1) = "TAG1A", (1.2) = "TAG1B"]
+	// [(2.1) = "TAG2A", (2.2) = "TAG2B"]
+	// [(3.1) = "TAG3A", (3.2) = "TAG3B"]
+
+	//RESULT:
+	// [(1.1.2.1.3.1)="TAG1A|TAG2A|TAG3A"]
+	// [(1.1.2.1.3.1)="TAG1A|TAG2A|TAG3B"]
+	// [(1.1.2.2.3.1)="TAG1A|TAG2B|TAG3A"]
+	// [(1.1.2.2.3.2)="TAG1A|TAG2B|TAG3B"]
+	// [(1.2.2.1.3.1)="TAG1B|TAG2A|TAG3A"]
+	// [(1.2.2.1.3.2)="TAG1B|TAG2A|TAG3B"]
+	// [(1.2.2.1.3.1)="TAG1B|TAG2B|TAG3A"]
+	// [(1.2.2.1.3.1)="TAG1B|TAG2B|TAG3B"]
+
+	// Merge process...
+	fresult, errmerge := MergeResults(resindex, suffix)
+	if errmerge != nil {
+		return nil, nil, errmerge
+	}
+	m.Debugf("Got final multiindex result index labels: %+v", fresult.CurIndexedLabels)
+	m.Debugf("Got final multiindex result tag names: %+v", fresult.TagName)
+
+	return fresult.CurIndexedLabels, fresult.TagName, nil
+}
+
+// LoadMultiIndex loads the multiindex with all attached measurements
+func (m *Measurement) LoadMultiIndex() error {
+
+	// Load MultiIndex labels based on dependencies
+	mil, tag, err := m.BuildMultiIndexLabels()
+	if err != nil {
+		return err
+	}
+
+	// Finally, set up base measurement
+	m.TagName = tag
+	m.AllIndexedLabels = mil
+	m.CurIndexedLabels = mil
+	m.MetricTable = NewMetricTable(m.cfg, m.log, mil)
+
+	m.InitBuildRuntime()
 	return nil
 }
 
@@ -146,17 +385,54 @@ func (m *Measurement) InitBuildRuntime() {
 
 }
 
-// AddFilter attach a filtering process to the measurement
-func (m *Measurement) AddFilter(f *config.MeasFilterCfg) error {
+// CheckInitFilter loads measurement filter on measurement if name/label is matched
+func (m *Measurement) CheckInitFilter(f *config.MeasFilterCfg) (bool, bool) {
+	// check if filter must be applied on base measurement
+	if m.cfg.GetMode != "value" && f.IDMeasurementCfg == m.ID {
+		m.FilterCfg = f
+		return true, false
+	}
+	// check if filter must be applied on multi index
+	if m.cfg.GetMode == "indexed_multiple" {
+		for _, mi := range m.MultiIndexMeas {
+			// to be unique, multiple filter is defined as base<ID>..index<ID>
+			if f.IDMeasurementCfg == mi.ID {
+				mi.FilterCfg = f
+				return true, true
+			}
+		}
+	}
+	return false, false
+}
+
+// AddFilter attach a filtering process to the measurement, but it is not initialized
+func (m *Measurement) AddFilter(f *config.MeasFilterCfg, multi bool) error {
 	var err error
 	if m.cfg.GetMode == "value" {
 		return fmt.Errorf("Error this measurement %s  is not indexed(snmptable) not Filter apply ", m.cfg.ID)
 	}
-	if f == nil {
+
+	// If multi, all multi indexes must be reloaded and reload main measurement
+	if multi {
+		m.AddMultiFilter()
+		err := m.LoadMultiIndex()
+		if err != nil {
+			return err
+		}
+	}
+
+	// If multi and the current measurement doesn't have any filter to be applied, just skip it
+	if m.FilterCfg == nil {
+		if multi {
+			m.Infof("No filter on base base measurement, skipping %s", m.cfg.ID)
+			return err
+		}
 		return fmt.Errorf("Error invalid  NIL  filter on measurment %s ", m.cfg.ID)
 	}
 
-	m.FilterCfg = f
+	// Filter is already set on check and init filter
+	// m.FilterCfg = f
+
 	switch m.FilterCfg.FType {
 	case "file":
 		m.Filter = filter.NewFileFilter(m.FilterCfg.FilterName, m.FilterCfg.EnableAlias, m.log)
@@ -209,7 +485,6 @@ func (m *Measurement) AddFilter(f *config.MeasFilterCfg) error {
 // UpdateFilter reload indexed with filters
 func (m *Measurement) UpdateFilter() (bool, error) {
 	var err error
-	//var newfilterlabels map[string]string
 
 	if m.cfg.GetMode == "value" {
 		return false, fmt.Errorf("Error this measurement %s  is not indexed(snmptable) not Filter apply ", m.cfg.ID)
@@ -217,13 +492,26 @@ func (m *Measurement) UpdateFilter() (bool, error) {
 
 	//fist update  all indexed--------
 	m.Infof("Re Loading Indexed values")
-	il, err2 := m.loadIndexedLabels()
 
-	if err2 != nil {
-		m.Errorf("Error while trying to reload Indexed Labels for baseOid %s : ERROR: %s", m.cfg.IndexOID, err)
-		return false, err
+	// if its indexed_multiple, we need to update internal filters and create the new metric table on based one
+	if m.cfg.GetMode == "indexed_multiple" {
+		m.UpdateMultiFilter()
+		il, _, err := m.BuildMultiIndexLabels()
+		if err != nil {
+			return false, err
+		}
+		m.AllIndexedLabels = il
+	} else {
+		il, err2 := m.loadIndexedLabels()
+
+		if err2 != nil {
+			m.Errorf("Error while trying to reload Indexed Labels for baseOid %s : ERROR: %s", m.cfg.IndexOID, err)
+			return false, err
+		}
+		m.AllIndexedLabels = il
 	}
-	m.AllIndexedLabels = il
+
+	// Reload measurement indexes
 	if m.Filter == nil {
 		m.Debugf("There is no filter configured in this measurement %s", m.cfg.ID)
 		//check if curindexed different of AllIndexed
@@ -315,7 +603,7 @@ func (m *Measurement) SnmpWalkData() (int64, int64, int64, error) {
 			processed++
 			metr.SetRawData(pdu, now)
 		} else {
-			m.Debugf("returned OID from device: %s  Not Found in measurement /metr list: %+v", pdu.Name, m.cfg.ID)
+			m.Debugf("returned OID from device: %s  Not Found in measurement /metr list: %+v, %v", pdu.Name, m.cfg.ID, m.OidSnmpMap)
 		}
 		return nil
 	}
@@ -401,7 +689,7 @@ func (m *Measurement) ComputeEvaluatedMetrics(catalog map[string]interface{}) {
 				m.Debugf("Evaluated metric not Found for Eval key %s", evalkey)
 			}
 		}
-	case "indexed", "indexed_it":
+	case "indexed", "indexed_it", "indexed_mit", "indexed_multiple":
 		for key, val := range m.CurIndexedLabels {
 			parameters := make(map[string]interface{})
 			//copy of the catalog map
@@ -541,7 +829,7 @@ func (m *Measurement) loadIndexedLabels() (map[string]string, error) {
 		m.Errorf("LOADINDEXEDLABELS - SNMP WALK error: %s", err)
 		return allindex, err
 	}
-	if m.cfg.GetMode != "indexed_it" {
+	if m.cfg.GetMode == "indexed" {
 		for k, v := range allindex {
 			allindex[k] = formatTag(m.log, m.cfg.IndexTagFormat, map[string]string{"IDX1": k, "VAL1": v}, "VAL1")
 		}
@@ -554,38 +842,89 @@ func (m *Measurement) loadIndexedLabels() (map[string]string, error) {
 		allindexOrigin[k] = v
 	}
 
-	//initialize allindex again
-	allindex = make(map[string]string)
-	m.curIdxPos = m.idx2PosInOID
-	err = m.Walk(m.cfg.TagOID, setRawData)
-	if err != nil {
-		m.Errorf("SNMP WALK over IndexOID error: %s", err)
-		return allindex, err
-	}
-
-	//At this point we have Indirect indexes on allindex_origin and values on allindex
-	// Example:
-	// allindexOrigin["1"]="9008"
-	//    key1="1"
-	//    val1="9008"
-	// allindex["9008"]="eth0"
-	//    key2="9008"
-	//    val2="eth0"
-	m.Debugf("ORIGINAL INDEX: %+v", allindexOrigin)
-	m.Debugf("INDIRECT  INDEX : %+v", allindex)
-
-	allindexIt := make(map[string]string)
-	for key1, val1 := range allindexOrigin {
-		if val2, ok := allindex[val1]; ok {
-			allindexIt[key1] = formatTag(m.log, m.cfg.IndexTagFormat, map[string]string{"IDX1": key1, "VAL1": val1, "IDX2": val1, "VAL2": val2}, "VAL2")
-		} else {
-			m.Warnf("There is not valid index : %s on TagOID : %s", val1, m.cfg.TagOID)
+	switch m.cfg.GetMode {
+	case "indexed_it":
+		//initialize allindex again
+		allindex = make(map[string]string)
+		m.curIdxPos = m.idx2PosInOID
+		err = m.Walk(m.cfg.TagOID, setRawData)
+		if err != nil {
+			m.Errorf("SNMP WALK over IndexOID error: %s", err)
+			return allindex, err
 		}
-	}
-	//-----------------------------------
 
-	if len(allindexOrigin) != len(allindexIt) {
-		m.Warnf("Not all indexes have been indirected\n First Idx [%+v]\n Tagged Idx [ %+v]", allindexOrigin, allindexIt)
+		//At this point we have Indirect indexes on allindex_origin and values on allindex
+		// Example:
+		// allindexOrigin["1"]="9008"
+		//    key1="1"
+		//    val1="9008"
+		// allindex["9008"]="eth0"
+		//    key2="9008"
+		//    val2="eth0"
+		m.Debugf("ORIGINAL INDEX: %+v", allindexOrigin)
+		m.Debugf("INDIRECT  INDEX : %+v", allindex)
+
+		allindexIt := make(map[string]string)
+		for key1, val1 := range allindexOrigin {
+			if val2, ok := allindex[val1]; ok {
+				allindexIt[key1] = formatTag(m.log, m.cfg.IndexTagFormat, map[string]string{"IDX1": key1, "VAL1": val1, "IDX2": val1, "VAL2": val2}, "VAL2")
+			} else {
+				m.Warnf("There is not valid index : %s on TagOID : %s", val1, m.cfg.TagOID)
+			}
+		}
+
+		if len(allindexOrigin) != len(allindexIt) {
+			m.Warnf("Not all indexes have been indirected\n First Idx [%+v]\n Tagged Idx [ %+v]", allindexOrigin, allindexIt)
+		}
+		return allindexIt, nil
+
+	case "indexed_mit":
+		//Make another copy of origin, we need to mantain always a base origin index
+		allindexRes := make(map[string]string, len(allindexOrigin))
+		for k, v := range allindexOrigin {
+			allindexRes[k] = v
+		}
+
+		// Go over all defined multipletagoid
+		for k, tagcfg := range m.cfg.MultiTagOID {
+			//initialize all index again
+			allindex = make(map[string]string)
+			//Store the last position to use it on allindex
+			m.curIdxPos = len(tagcfg.TagOID)
+			err = m.Walk(tagcfg.TagOID, setRawData)
+			if err != nil {
+				m.Errorf("SNMP WALK over IndexOID error: %s", err)
+				return allindex, err
+			}
+			// Create a base map, we need it to mantain the key1 as the first index, so we can reference it back to as the core index
+			allindexIt := make(map[string]string)
+			// Start logic of match
+			for key1, val1 := range allindexRes {
+				// As we only need the value to keep going on the different tables, we can create a custom check field if the index is not the same as original
+				// It is used on qos to get parent cfg oids
+				check := formatTag(m.log, tagcfg.IndexFormat, map[string]string{"IDX1": key1, "VAL1": val1}, "VAL1")
+				if val2, ok := allindex[check]; ok {
+					//Only apply formatTag based on the last index...
+					if k == len(m.cfg.MultiTagOID)-1 {
+						allindexIt[key1] = formatTag(m.log, m.cfg.IndexTagFormat, map[string]string{"IDX1": key1, "VAL1": val1, "IDX2": val1, "VAL2": val2}, "VAL2")
+						continue
+					}
+					allindexIt[key1] = val2
+				} else {
+					// Set debug due to large logs generated. This case is generic, so a not match can be normal
+					m.Debugf("[%d] - There is not valid index : %s on TagOID : %s", k, val1, tagcfg.TagOID)
+				}
+			}
+			allindexRes = allindexIt
+		}
+
+		if len(allindexOrigin) != len(allindexRes) {
+			m.Warnf("Not all indexes have been indirected\n First Idx [%+v]\n Tagged Idx [ %+v]", allindexOrigin, allindexRes)
+		}
+
+		return allindexRes, nil
+
+	default:
+		return allindex, fmt.Errorf("Uknown provided getmode %s on measurement %s", m.cfg.GetMode, m.ID)
 	}
-	return allindexIt, nil
 }

--- a/pkg/data/measurement/measurement_test.go
+++ b/pkg/data/measurement/measurement_test.go
@@ -31,6 +31,7 @@ func ProcessMeasurementFull(m *Measurement, varmap map[string]interface{}) error
 	m.ComputeEvaluatedMetrics(varmap)
 
 	m.Infof("GETS: %d,NPROCS: %d ,NERRS %d", nGets, nProcs, nErrs)
+	m.Infof("GOT CURR INDEXED VALUES --> %+v ", m.CurIndexedLabels)
 	return nil
 }
 
@@ -64,12 +65,14 @@ func OrderMapByKey(m map[string]string) string {
 }
 
 func GetOutputInfluxMetrics(m *Measurement) {
+	m.Infof("GOT MEAS --> %+v", m)
 
 	metSent, metError, measSent, measError, ptarray := m.GetInfluxPoint(map[string]string{})
 
 	m.Infof("METRIC SENT[%d],METRIC ERROR[%d],MEAS SENT[%d], MEAS ERROR[%d]", metSent, metError, measSent, measError)
 
 	for _, v := range ptarray {
+		m.Infof("GOT V %+v", v)
 		fields, _ := v.Fields()
 		tags := OrderMapByKey(v.Tags())
 
@@ -347,6 +350,2069 @@ func Example_Measurement_GetMode_Indexed() {
 
 }
 
+func Example_Measurement_GetMode_Indexed_Indirect() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			{Name: ".1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4", Type: gosnmp.Integer, Value: int(24)},
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.2.3", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.2.4", Type: gosnmp.Integer, Value: int(93)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.4.92", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.4.93", Type: gosnmp.OctetString, Value: "eth4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:             "interfaces_data",
+		Name:           "interfaces_data",
+		GetMode:        "indexed_it",
+		IndexOID:       ".1.2",
+		TagOID:         ".1.4",
+		IndexTag:       "portName",
+		IndexTagFormat: "",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:output ValueType:int64  Value:24
+
+}
+
+func Example_Measurement_GetMode_Indexed_Multi_Indirect() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	lev, _ := logrus.ParseLevel("debug")
+
+	l.SetLevel(lev)
+
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.1", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.1", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.1", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.1", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.1", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.1", Type: gosnmp.Integer, Value: int(24)},
+			//Indirect Table
+			{Name: ".1.2.1.1", Type: gosnmp.Integer, Value: int(2)},
+			{Name: ".1.2.2.1", Type: gosnmp.Integer, Value: int(2)},
+			{Name: ".1.2.3.1", Type: gosnmp.Integer, Value: int(2)},
+			{Name: ".1.2.4.1", Type: gosnmp.Integer, Value: int(2)},
+
+			{Name: ".1.10.1.2", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.10.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.10.3.2", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.10.4.2", Type: gosnmp.Integer, Value: int(93)},
+
+			{Name: ".1.4.90", Type: gosnmp.Integer, Value: int(94)},
+			{Name: ".1.4.91", Type: gosnmp.Integer, Value: int(95)},
+			{Name: ".1.4.92", Type: gosnmp.Integer, Value: int(96)},
+			{Name: ".1.4.93", Type: gosnmp.Integer, Value: int(97)},
+
+			{Name: ".1.5.94", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.5.95", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.5.96", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.5.97", Type: gosnmp.OctetString, Value: "eth4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:       "interfaces_data",
+		Name:     "interfaces_data",
+		GetMode:  "indexed_mit",
+		IndexOID: ".1.2",
+		MultiTagOID: []config.MultipleTagOID{
+			{
+				TagOID:      ".1.10",
+				IndexFormat: "${IDX1|DOT[0:0]|STRING}.$VAL1",
+			},
+			{
+				TagOID:      ".1.4",
+				IndexFormat: "",
+			},
+			{
+				TagOID:      ".1.5",
+				IndexFormat: "",
+			},
+		},
+		IndexTag:       "portName",
+		IndexTagFormat: "",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:output ValueType:int64  Value:24
+
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			{Name: ".1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4", Type: gosnmp.Integer, Value: int(24)},
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.2.3", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.2.4", Type: gosnmp.Integer, Value: int(93)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.4.92", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.4.93", Type: gosnmp.OctetString, Value: "eth4"},
+			{Name: ".1.6.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.4", Type: gosnmp.OctetString, Value: "port4"},
+			{Name: ".1.7.1", Type: gosnmp.OctetString, Value: "myPort1"},
+			{Name: ".1.7.2", Type: gosnmp.OctetString, Value: "myPort2"},
+			{Name: ".1.7.3", Type: gosnmp.OctetString, Value: "myPort3"},
+			{Name: ".1.7.4", Type: gosnmp.OctetString, Value: "myPort4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     "IDX{0}",
+			},
+			{
+				Label:          "ifAlias",
+				IndexOID:       ".1.7",
+				IndexTag:       "portAlias",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     "IDX{1};DOT[0:0];FILL(Not defined)",
+			},
+		},
+		MultiIndexResult: "IDX{2}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portAlias:myPort2, portDesc:Not defined, portName:Not defined } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portAlias:myPort2, portDesc:Not defined, portName:Not defined } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portAlias:myPort3, portDesc:Not defined, portName:Not defined } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portAlias:myPort3, portDesc:Not defined, portName:Not defined } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portAlias:myPort4, portDesc:port4, portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portAlias:myPort4, portDesc:port4, portName:eth4 } Field:output ValueType:int64  Value:24
+	// Measurement:interfaces_data Tags:{ portAlias:myPort1, portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portAlias:myPort1, portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndexDIM2() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.2.3", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.2.4", Type: gosnmp.Integer, Value: int(93)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.4.92", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.4.93", Type: gosnmp.OctetString, Value: "eth4"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     "IDX{0};DOT[0:0];SKIP",
+			},
+		},
+		MultiIndexResult: "IDX{1}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portDesc:port3, portName:eth3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portDesc:port3, portName:eth3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portDesc:port4, portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portDesc:port4, portName:eth4 } Field:output ValueType:int64  Value:24
+
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_SKIP() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];SKIP`,
+			},
+		},
+		MultiIndexResult: "IDX{1}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_FILLNONE() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];FILL()`,
+			},
+		},
+		MultiIndexResult: "IDX{1}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portDesc:port3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portDesc:port3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portDesc:port4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portDesc:port4 } Field:output ValueType:int64  Value:24
+
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_FILLSTRING() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];FILL(NotRelated)`,
+			},
+		},
+		MultiIndexResult: "IDX{1}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portDesc:port3, portName:NotRelated } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portDesc:port3, portName:NotRelated } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portDesc:port4, portName:NotRelated } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portDesc:port4, portName:NotRelated } Field:output ValueType:int64  Value:24
+
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_SKIP_CUSTOMRESULT() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2.1", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3.1", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4.1", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2.1", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3.1", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4.1", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];SKIP`,
+			},
+		},
+		MultiIndexResult: "IDX{1}.1",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_SKIP_CUSTOMRESULT_COMPLEX() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1.1.5", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2.1.6", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3.1.5", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4.1.6", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1.1.5", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2.1.6", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3.1.5", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4.1.6", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+			//Direct table
+			{Name: ".1.7.5", Type: gosnmp.OctetString, Value: "5"},
+			{Name: ".1.7.6", Type: gosnmp.OctetString, Value: "6"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];SKIP`,
+			},
+			{
+				Label:          "ifType",
+				IndexOID:       ".1.7",
+				IndexTag:       "ifType",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     ``,
+			},
+		},
+		MultiIndexResult: "IDX{1}.1.IDX{2}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_DIM2_FILLNONE_CUSTOMRESULT_COMPLEX() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1.1.1.5", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2.2.1.6", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3.3.1.5", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4.4.1.6", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1.1.1.5", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2.2.1.6", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3.3.1.5", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4.4.1.6", Type: gosnmp.Integer, Value: int(24)},
+			//Measurement tables
+			//Indirect Table
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			//Direct table
+			{Name: ".1.6.1.1", Type: gosnmp.OctetString, Value: "port1"},
+			{Name: ".1.6.2.2", Type: gosnmp.OctetString, Value: "port2"},
+			{Name: ".1.6.3.3", Type: gosnmp.OctetString, Value: "port3"},
+			{Name: ".1.6.4.4", Type: gosnmp.OctetString, Value: "port4"},
+			//Direct table
+			{Name: ".1.7.5", Type: gosnmp.OctetString, Value: "5"},
+			{Name: ".1.7.6", Type: gosnmp.OctetString, Value: "6"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "ifName",
+				IndexOID:       ".1.2",
+				TagOID:         ".1.4",
+				IndexTag:       "portName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "ifDesc",
+				IndexOID:       ".1.6",
+				IndexTag:       "portDesc",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];FILL()`,
+			},
+			{
+				Label:          "ifType",
+				IndexOID:       ".1.7",
+				IndexTag:       "ifType",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     ``,
+			},
+		},
+		MultiIndexResult: "IDX{1}.1.IDX{2}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port1, portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port1, portName:eth1 } Field:output ValueType:int64  Value:21
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port2, portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port2, portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ ifType:5, portDesc:port3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ ifType:6, portDesc:port4 } Field:output ValueType:int64  Value:24
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_QOS_CMSTATS() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			// cbQosCMPrePolicyPkt64
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.3.1043.1045", Type: gosnmp.Counter64, Value: uint64(8)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.3.1043.1051", Type: gosnmp.Counter64, Value: uint64(1131)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.3.1099.1101", Type: gosnmp.Counter64, Value: uint64(281)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.3.1099.1107", Type: gosnmp.Counter64, Value: uint64(7016)},
+			//cbQosCMPrePolicyByte64
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.6.1043.1045", Type: gosnmp.Counter64, Value: uint64(784)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.6.1043.1051", Type: gosnmp.Counter64, Value: uint64(114630)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.6.1099.1101", Type: gosnmp.Counter64, Value: uint64(69858)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.15.1.1.6.1099.1107", Type: gosnmp.Counter64, Value: uint64(658800)},
+			//	cbQoSIfIndex
+			//	- cbQoSIfIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.4.1043", Type: gosnmp.Integer, Value: int(1)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.4.1099", Type: gosnmp.Integer, Value: int(1)},
+			{Name: ".1.3.6.1.2.1.31.1.1.1.1.1", Type: gosnmp.OctetString, Value: "FastEthernet0/0"},
+			//	cbQosPolicyDirection
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.3.1043", Type: gosnmp.Integer, Value: int(2)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.3.1099", Type: gosnmp.Integer, Value: int(1)}, //FastEthernet0/0 | input
+
+			// cbQosPolicyMapName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1045", Type: gosnmp.Integer, Value: int(1043)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1051", Type: gosnmp.Integer, Value: int(1043)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1101", Type: gosnmp.Integer, Value: int(1099)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1107", Type: gosnmp.Integer, Value: int(1099)},
+
+			// cbQosParentObjectsIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1043", Type: gosnmp.Integer, Value: int(1035)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1099", Type: gosnmp.Integer, Value: int(1063)},
+
+			// - cbQosPolicyMapName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1.1035", Type: gosnmp.OctetString, Value: "LAN_Out"},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1.1063", Type: gosnmp.OctetString, Value: "CPP"},
+
+			//	cbQosCMName
+			//	- cbQosConfigIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1045", Type: gosnmp.Integer, Value: int(1029)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1051", Type: gosnmp.Integer, Value: int(1025)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1101", Type: gosnmp.Integer, Value: int(1057)}, //FastEthernet0/0 | input
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1107", Type: gosnmp.Integer, Value: int(1025)}, //FastEthernet0/0 | input
+			//- cbQosCMName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1025", Type: gosnmp.OctetString, Value: "class-default"}, //FastEthernet0/0 | output | class-default || //FastEthernet0/0 | input | class-default
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1029", Type: gosnmp.OctetString, Value: "ICMP"},          //FastEthernet0/0 | input | ICMP
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1057", Type: gosnmp.OctetString, Value: "NonLocal"},      //FastEthernet0/0 | input | NonLocal
+			//- cbQosCMInfo
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1025", Type: gosnmp.Integer, Value: int(3)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1029", Type: gosnmp.Integer, Value: int(2)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1057", Type: gosnmp.Integer, Value: int(3)},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"cisco_cbQosCMPrePolicyPkt64": {
+			ID:          "cisco_cbQosCMPrePolicyPkt64",
+			FieldName:   "cbQosCMPrePolicyPkt64",
+			Description: "",
+			BaseOID:     ".1.3.6.1.4.1.9.9.166.1.15.1.1.3",
+			DataSrcType: "Counter64",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"cisco_cbQosCMPrePolicyByte64": {
+			ID:          "cisco_cbQosCMPrePolicyByte64",
+			FieldName:   "cbQosCMPrePolicyByte64",
+			Description: "",
+			BaseOID:     ".1.3.6.1.4.1.9.9.166.1.15.1.1.6",
+			DataSrcType: "Counter64",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "cbQosIfIndex",
+				Description:    "Index to retrieve interface name from cbQosIfIndex",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.1.1.1.4",
+				TagOID:         ".1.3.6.1.2.1.31.1.1.1.1",
+				IndexTag:       "ifName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "cbQosPolicyDirection",
+				Description:    "Index to retrieve interface Policy Direction",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.1.1.1.3",
+				IndexTag:       "policyDirection",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];SKIP`,
+			},
+			{
+				Label:          "cbQosCMName",
+				Description:    "Index to retrieve CMName",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.5.1.1.2",
+				TagOID:         ".1.3.6.1.4.1.9.9.166.1.7.1.1.1",
+				IndexTag:       "cmName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     `IDX{1};DOT[0:0];SKIP`,
+			},
+			{
+				Label:       "cbQosPolicyMapName",
+				Description: "Index to retrieve cbQosPolicyMapName",
+				IndexOID:    ".1.3.6.1.4.1.9.9.166.1.5.1.1.4",
+				MultiTagOID: []config.MultipleTagOID{
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2", IndexFormat: "${IDX1|DOT[0:0]|STRING}.$VAL1"},
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1", IndexFormat: ""},
+				},
+				IndexTag:       "policyMapName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_mit",
+				Dependency:     `IDX{2};DOT[0:1];SKIP`,
+			},
+			{
+				Label:          "cbQosCMInfo",
+				Description:    "Index to retrieve cbQosCMInfo",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.5.1.1.2",
+				TagOID:         ".1.3.6.1.4.1.9.9.166.1.7.1.1.3",
+				IndexTag:       "cmInfo",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     `IDX{3};DOT[0:1];SKIP`,
+			},
+		},
+		MultiIndexResult: "IDX{4}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "cisco_cbQosCMPrePolicyPkt64", Report: metric.AlwaysReport},
+			{ID: "cisco_cbQosCMPrePolicyByte64", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:NonLocal, ifName:FastEthernet0/0, policyDirection:1, policyMapName:CPP } Field:cbQosCMPrePolicyByte64 ValueType:int64  Value:69858
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:NonLocal, ifName:FastEthernet0/0, policyDirection:1, policyMapName:CPP } Field:cbQosCMPrePolicyPkt64 ValueType:int64  Value:281
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:class-default, ifName:FastEthernet0/0, policyDirection:1, policyMapName:CPP } Field:cbQosCMPrePolicyByte64 ValueType:int64  Value:658800
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:class-default, ifName:FastEthernet0/0, policyDirection:1, policyMapName:CPP } Field:cbQosCMPrePolicyPkt64 ValueType:int64  Value:7016
+	// Measurement:interfaces_data Tags:{ cmInfo:2, cmName:ICMP, ifName:FastEthernet0/0, policyDirection:2, policyMapName:LAN_Out } Field:cbQosCMPrePolicyByte64 ValueType:int64  Value:784
+	// Measurement:interfaces_data Tags:{ cmInfo:2, cmName:ICMP, ifName:FastEthernet0/0, policyDirection:2, policyMapName:LAN_Out } Field:cbQosCMPrePolicyPkt64 ValueType:int64  Value:8
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:class-default, ifName:FastEthernet0/0, policyDirection:2, policyMapName:LAN_Out } Field:cbQosCMPrePolicyByte64 ValueType:int64  Value:114630
+	// Measurement:interfaces_data Tags:{ cmInfo:3, cmName:class-default, ifName:FastEthernet0/0, policyDirection:2, policyMapName:LAN_Out } Field:cbQosCMPrePolicyPkt64 ValueType:int64  Value:1131
+}
+
+func Example_Measurement_GetMode_Indexed_MultiIndex_QOS_MATCH_NAME() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			// cbQosMatchPrePolicyPkt64
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.3.1043.1047", Type: gosnmp.Counter64, Value: uint64(8)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.3.1043.1053", Type: gosnmp.Counter64, Value: uint64(1131)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.3.1099.1103", Type: gosnmp.Counter64, Value: uint64(281)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.3.1099.1109", Type: gosnmp.Counter64, Value: uint64(7016)},
+			//cbQosCMPrePolicyByte64
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.6.1043.1047", Type: gosnmp.Counter64, Value: uint64(784)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.6.1043.1053", Type: gosnmp.Counter64, Value: uint64(114630)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.6.1099.1103", Type: gosnmp.Counter64, Value: uint64(69858)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.16.1.1.6.1099.1109", Type: gosnmp.Counter64, Value: uint64(658800)},
+			//	cbQoSIfIndex
+			//	- cbQoSIfIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.4.1043", Type: gosnmp.Integer, Value: int(1)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.4.1099", Type: gosnmp.Integer, Value: int(1)},
+			{Name: ".1.3.6.1.2.1.31.1.1.1.1.1", Type: gosnmp.OctetString, Value: "FastEthernet0/0"},
+			//	cbQosPolicyDirection
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.3.1043", Type: gosnmp.Integer, Value: int(2)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.1.1.1.3.1099", Type: gosnmp.Integer, Value: int(1)}, //FastEthernet0/0 | input
+
+			// cbQosPolicyMapName
+			// - cbQosParentObjectsIndex
+			// -- CM -> Policy
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1045", Type: gosnmp.Integer, Value: int(1043)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1051", Type: gosnmp.Integer, Value: int(1043)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1101", Type: gosnmp.Integer, Value: int(1099)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1107", Type: gosnmp.Integer, Value: int(1099)},
+			// -- Match -> CM
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1047", Type: gosnmp.Integer, Value: int(1045)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1043.1053", Type: gosnmp.Integer, Value: int(1051)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1103", Type: gosnmp.Integer, Value: int(1101)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4.1099.1109", Type: gosnmp.Integer, Value: int(1107)},
+
+			// cbQosParentObjectsIndex
+			// - cbQosConfigIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1043", Type: gosnmp.Integer, Value: int(1035)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1099", Type: gosnmp.Integer, Value: int(1063)},
+
+			// - cbQosPolicyMapName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1.1035", Type: gosnmp.OctetString, Value: "LAN_Out"},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1.1063", Type: gosnmp.OctetString, Value: "CPP"},
+
+			//	cbQosCMName
+			//	- cbQosConfigIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1045", Type: gosnmp.Integer, Value: int(1029)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1051", Type: gosnmp.Integer, Value: int(1025)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1101", Type: gosnmp.Integer, Value: int(1057)}, //FastEthernet0/0 | input
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1107", Type: gosnmp.Integer, Value: int(1025)}, //FastEthernet0/0 | input
+			//- cbQosCMName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1025", Type: gosnmp.OctetString, Value: "class-default"}, //FastEthernet0/0 | output | class-default || //FastEthernet0/0 | input | class-default
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1029", Type: gosnmp.OctetString, Value: "ICMP"},          //FastEthernet0/0 | input | ICMP
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1.1057", Type: gosnmp.OctetString, Value: "NonLocal"},      //FastEthernet0/0 | input | NonLocal
+			//- cbQosCMInfo
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1025", Type: gosnmp.Integer, Value: int(3)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1029", Type: gosnmp.Integer, Value: int(2)},
+			{Name: ".1.3.6.1.4.1.9.9.166.1.7.1.1.3.1057", Type: gosnmp.Integer, Value: int(3)},
+
+			// cbQosMatchStmtName
+			// - cbQosConfigIndex
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1047", Type: gosnmp.Integer, Value: int(1053)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1043.1053", Type: gosnmp.Integer, Value: int(1053)}, //FastEthernet0/0 | output
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1103", Type: gosnmp.Integer, Value: int(1054)}, //FastEthernet0/0 | input
+			{Name: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2.1099.1109", Type: gosnmp.Integer, Value: int(1054)}, //FastEthernet0/0 | input
+
+			// - cbQosMatchStmtName
+			{Name: ".1.3.6.1.4.1.9.9.166.1.8.1.1.1.1053", Type: gosnmp.OctetString, Value: "CLASS_BACKUP"},   //FastEthernet0/0 | output | class-default || //FastEthernet0/0 | input | class-default
+			{Name: ".1.3.6.1.4.1.9.9.166.1.8.1.1.1.1054", Type: gosnmp.OctetString, Value: "CLASS_INTERNET"}, //FastEthernet0/0 | input | ICMP
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"cisco_cbQosMatchPrePolicyPkt64": {
+			ID: "cisco_cbQosMatchPrePolicyPkt64",
+			FieldName: "cbQosMatchPrePolicyPkt64	",
+			Description: "",
+			BaseOID:     ".1.3.6.1.4.1.9.9.166.1.16.1.1.3",
+			DataSrcType: "Counter64",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"cisco_cbQosMatchPrePolicyByte64": {
+			ID:          "cisco_cbQosMatchPrePolicyByte64",
+			FieldName:   "cbQosMatchPrePolicyByte64",
+			Description: "",
+			BaseOID:     ".1.3.6.1.4.1.9.9.166.1.16.1.1.6",
+			DataSrcType: "Counter64",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:      "interfaces_data",
+		Name:    "interfaces_data",
+		GetMode: "indexed_multiple",
+		MultiIndexCfg: []config.MultiIndexCfg{
+			{
+				Label:          "cbQosIfIndex",
+				Description:    "Index to retrieve interface name from cbQosIfIndex",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.1.1.1.4",
+				TagOID:         ".1.3.6.1.2.1.31.1.1.1.1",
+				IndexTag:       "ifName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     "",
+			},
+			{
+				Label:          "cbQosPolicyDirection",
+				Description:    "Index to retrieve interface Policy Direction",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.1.1.1.3",
+				IndexTag:       "policyDirection",
+				IndexTagFormat: "",
+				GetMode:        "indexed",
+				Dependency:     `IDX{0};DOT[0:0];SKIP`,
+			},
+			{
+				Label:       "cbQosCMName",
+				Description: "Index to retrieve CMName",
+				IndexOID:    ".1.3.6.1.4.1.9.9.166.1.5.1.1.4",
+				MultiTagOID: []config.MultipleTagOID{
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2", IndexFormat: "${IDX1|DOT[0:0]|STRING}.$VAL1"},
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.7.1.1.1", IndexFormat: ""},
+				},
+				IndexTag:       "cmName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_mit",
+				Dependency:     `IDX{1};DOT[0:0];SKIP`,
+			},
+			{
+				Label:       "cbQosPolicyMapName",
+				Description: "Index to retrieve cbQosPolicyMapName",
+				IndexOID:    ".1.3.6.1.4.1.9.9.166.1.5.1.1.4",
+				MultiTagOID: []config.MultipleTagOID{
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.5.1.1.4", IndexFormat: "${IDX1|DOT[0:0]|STRING}.$VAL1"},
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.5.1.1.2", IndexFormat: "${IDX1|DOT[0:0]|STRING}.$VAL1"},
+					{TagOID: ".1.3.6.1.4.1.9.9.166.1.6.1.1.1", IndexFormat: ""},
+				},
+				IndexTag:       "policyMapName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_mit",
+				Dependency:     `IDX{2};DOT[0:1];SKIP`,
+			},
+			{
+				Label:          "cbQosMatchStmtName",
+				Description:    "Index to retrieve cbQosMatchStmtName",
+				IndexOID:       ".1.3.6.1.4.1.9.9.166.1.5.1.1.2",
+				TagOID:         ".1.3.6.1.4.1.9.9.166.1.8.1.1.1",
+				IndexTag:       "matchStmtName",
+				IndexTagFormat: "",
+				GetMode:        "indexed_it",
+				Dependency:     `IDX{3};DOT[0:1];SKIP`,
+			},
+		},
+		MultiIndexResult: "IDX{4}",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "cisco_cbQosMatchPrePolicyPkt64", Report: metric.AlwaysReport},
+			{ID: "cisco_cbQosMatchPrePolicyByte64", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ cmName:ICMP, ifName:FastEthernet0/0, matchStmtName:CLASS_BACKUP, policyDirection:2, policyMapName:LAN_Out } Field:cbQosMatchPrePolicyPkt64	 ValueType:int64  Value:8
+	// Measurement:interfaces_data Tags:{ cmName:ICMP, ifName:FastEthernet0/0, matchStmtName:CLASS_BACKUP, policyDirection:2, policyMapName:LAN_Out } Field:cbQosMatchPrePolicyByte64 ValueType:int64  Value:784
+	// Measurement:interfaces_data Tags:{ cmName:NonLocal, ifName:FastEthernet0/0, matchStmtName:CLASS_INTERNET, policyDirection:1, policyMapName:CPP } Field:cbQosMatchPrePolicyByte64 ValueType:int64  Value:69858
+	// Measurement:interfaces_data Tags:{ cmName:NonLocal, ifName:FastEthernet0/0, matchStmtName:CLASS_INTERNET, policyDirection:1, policyMapName:CPP } Field:cbQosMatchPrePolicyPkt64	 ValueType:int64  Value:281
+	// Measurement:interfaces_data Tags:{ cmName:class-default, ifName:FastEthernet0/0, matchStmtName:CLASS_INTERNET, policyDirection:1, policyMapName:CPP } Field:cbQosMatchPrePolicyByte64 ValueType:int64  Value:658800
+	// Measurement:interfaces_data Tags:{ cmName:class-default, ifName:FastEthernet0/0, matchStmtName:CLASS_INTERNET, policyDirection:1, policyMapName:CPP } Field:cbQosMatchPrePolicyPkt64	 ValueType:int64  Value:7016
+	// Measurement:interfaces_data Tags:{ cmName:class-default, ifName:FastEthernet0/0, matchStmtName:CLASS_BACKUP, policyDirection:2, policyMapName:LAN_Out } Field:cbQosMatchPrePolicyByte64 ValueType:int64  Value:114630
+	// Measurement:interfaces_data Tags:{ cmName:class-default, ifName:FastEthernet0/0, matchStmtName:CLASS_BACKUP, policyDirection:2, policyMapName:LAN_Out } Field:cbQosMatchPrePolicyPkt64	 ValueType:int64  Value:1131
+}
+
 func Example_Measurement_value_STRINGEVAL() {
 
 	// 1.- LOGGER SETUP
@@ -602,6 +2668,334 @@ func Example_Measurement_Indexed_STRINGEVAL() {
 		GetMode:        "indexed",
 		IndexOID:       ".1.2",
 		TagOID:         "",
+		IndexTag:       "portName",
+		IndexTagFormat: "",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+			{ID: "value_total", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:total ValueType:int64  Value:74
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:total ValueType:int64  Value:76
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:output ValueType:int64  Value:24
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:total ValueType:int64  Value:78
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:total ValueType:int64  Value:72
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:output ValueType:int64  Value:21
+
+}
+
+func Example_Measurement_Indexed_Indirect_STRINGEVAL() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			{Name: ".1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4", Type: gosnmp.Integer, Value: int(24)},
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.2.3", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.2.4", Type: gosnmp.Integer, Value: int(93)},
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.4.92", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.4.93", Type: gosnmp.OctetString, Value: "eth4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_total": {
+			ID:          "value_total",
+			FieldName:   "total",
+			Description: "",
+			BaseOID:     "",
+			DataSrcType: "STRINGEVAL",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "input + output",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:             "interfaces_data",
+		Name:           "interfaces_data",
+		GetMode:        "indexed_it",
+		IndexOID:       ".1.2",
+		TagOID:         ".1.4",
+		IndexTag:       "portName",
+		IndexTagFormat: "",
+		Fields: []config.MeasurementFieldReport{
+			{ID: "value_input", Report: metric.AlwaysReport},
+			{ID: "value_output", Report: metric.AlwaysReport},
+			{ID: "value_total", Report: metric.AlwaysReport},
+		},
+	}
+
+	cfg.Init(&metrics, vars)
+
+	// 6.- MEASUREMENT ENGINE SETUP
+
+	m, err := New(cfg, l, cli, false)
+	if err != nil {
+		l.Errorf("Can not create measurement %s", err)
+		return
+	}
+
+	// 7.- PROCESS AND VERIFY
+
+	err = ProcessMeasurementFull(m, vars)
+	if err != nil {
+		l.Errorf("Can not process measurement %s", err)
+		return
+	}
+
+	GetOutputInfluxMetrics(m)
+
+	// Unordered Output:
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:input ValueType:int64  Value:52
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:output ValueType:int64  Value:22
+	// Measurement:interfaces_data Tags:{ portName:eth2 } Field:total ValueType:int64  Value:74
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:input ValueType:int64  Value:53
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:output ValueType:int64  Value:23
+	// Measurement:interfaces_data Tags:{ portName:eth3 } Field:total ValueType:int64  Value:76
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:input ValueType:int64  Value:54
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:output ValueType:int64  Value:24
+	// Measurement:interfaces_data Tags:{ portName:eth4 } Field:total ValueType:int64  Value:78
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:total ValueType:int64  Value:72
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:input ValueType:int64  Value:51
+	// Measurement:interfaces_data Tags:{ portName:eth1 } Field:output ValueType:int64  Value:21
+
+}
+
+func Example_Measurement_Indexed_Multi_Indirect_STRINGEVAL() {
+
+	// 1.- SETUP LOGGER
+
+	l := logrus.New()
+	//l.Level = logrus.DebugLevel
+
+	mock.SetLogger(l)
+	config.SetLogger(l)
+
+	// 2.- MOCK SERVER SETUP
+
+	s := &mock.SnmpServer{
+		Listen: "127.0.0.1:1161",
+		Want: []gosnmp.SnmpPDU{
+			//Metrics
+			{Name: ".1.1.1", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.1.2", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.1.3", Type: gosnmp.Integer, Value: int(53)},
+			{Name: ".1.1.4", Type: gosnmp.Integer, Value: int(54)},
+			{Name: ".1.3.1", Type: gosnmp.Integer, Value: int(21)},
+			{Name: ".1.3.2", Type: gosnmp.Integer, Value: int(22)},
+			{Name: ".1.3.3", Type: gosnmp.Integer, Value: int(23)},
+			{Name: ".1.3.4", Type: gosnmp.Integer, Value: int(24)},
+
+			//Tables
+			{Name: ".1.2.1", Type: gosnmp.Integer, Value: int(50)},
+			{Name: ".1.2.2", Type: gosnmp.Integer, Value: int(51)},
+			{Name: ".1.2.3", Type: gosnmp.Integer, Value: int(52)},
+			{Name: ".1.2.4", Type: gosnmp.Integer, Value: int(53)},
+
+			//Tables
+			{Name: ".1.5.50", Type: gosnmp.Integer, Value: int(90)},
+			{Name: ".1.5.51", Type: gosnmp.Integer, Value: int(91)},
+			{Name: ".1.5.52", Type: gosnmp.Integer, Value: int(92)},
+			{Name: ".1.5.53", Type: gosnmp.Integer, Value: int(93)},
+
+			//Tables
+			{Name: ".1.4.90", Type: gosnmp.OctetString, Value: "eth1"},
+			{Name: ".1.4.91", Type: gosnmp.OctetString, Value: "eth2"},
+			{Name: ".1.4.92", Type: gosnmp.OctetString, Value: "eth3"},
+			{Name: ".1.4.93", Type: gosnmp.OctetString, Value: "eth4"},
+		},
+	}
+
+	err := s.Start()
+	if err != nil {
+		l.Errorf("error on start snmp mock server: %s", err)
+		return
+	}
+	defer s.Stop()
+
+	// 3.- SNMP CLIENT SETUP
+
+	cli := &gosnmp.GoSNMP{
+		Target:    "127.0.0.1",
+		Port:      1161,
+		Version:   gosnmp.Version2c,
+		Community: "test1",
+		Timeout:   5 * time.Second,
+		Retries:   0,
+		Logger:    l,
+	}
+	err = cli.Connect()
+	if err != nil {
+		l.Fatalf("Connect() err: %v", err)
+	}
+	defer cli.Conn.Close()
+
+	// 4.- METRICMAP SETUP
+
+	metrics := map[string]*config.SnmpMetricCfg{
+		"value_input": {
+			ID:          "value_input",
+			FieldName:   "input",
+			Description: "",
+			BaseOID:     ".1.1",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_output": {
+			ID:          "value_output",
+			FieldName:   "output",
+			Description: "",
+			BaseOID:     ".1.3",
+			DataSrcType: "Integer32",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "",
+			Conversion:  1,
+		},
+		"value_total": {
+			ID:          "value_total",
+			FieldName:   "total",
+			Description: "",
+			BaseOID:     "",
+			DataSrcType: "STRINGEVAL",
+			GetRate:     false,
+			Scale:       0.0,
+			Shift:       0.0,
+			IsTag:       false,
+			ExtraData:   "input + output",
+			Conversion:  1,
+		},
+	}
+
+	// 5.- MEASUREMENT CONFIG SETUP
+
+	vars := map[string]interface{}{}
+
+	cfg := &config.MeasurementCfg{
+		ID:       "interfaces_data",
+		Name:     "interfaces_data",
+		GetMode:  "indexed_mit",
+		IndexOID: ".1.2",
+		MultiTagOID: []config.MultipleTagOID{
+			{TagOID: ".1.5", IndexFormat: ""},
+			{TagOID: ".1.4", IndexFormat: ""},
+		},
 		IndexTag:       "portName",
 		IndexTagFormat: "",
 		Fields: []config.MeasurementFieldReport{

--- a/pkg/data/measurement/metrictable.go
+++ b/pkg/data/measurement/metrictable.go
@@ -188,7 +188,7 @@ func (mt *MetricTable) Init(c *config.MeasurementCfg, l *logrus.Logger, CurIndex
 		idx.SetVisible(mt.visible)
 		mt.AddRow("0", idx)
 
-	case "indexed", "indexed_it":
+	case "indexed", "indexed_it", "indexed_mit", "indexed_multiple":
 		//for each field an each index (previously initialized)
 		for key, label := range CurIndexedLabels {
 			idx := NewMetricRow()

--- a/src/common/generic-modal.ts
+++ b/src/common/generic-modal.ts
@@ -1,11 +1,11 @@
 import { Component, Input, Output, Pipe, PipeTransform, ViewChild, EventEmitter } from '@angular/core';
-import { FormGroup,FormControl } from '@angular/forms';
+import { FormGroup, FormControl } from '@angular/forms';
 import { ModalDirective } from 'ngx-bootstrap';
 
 
 @Component({
-    selector: 'test-modal',
-    template: `
+  selector: 'test-modal',
+  template: `
       <div bsModal #childModal="bs-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
           <div class="modal-dialog">
             <div class="modal-content">
@@ -25,17 +25,25 @@ import { ModalDirective } from 'ngx-bootstrap';
                 <div  *ngFor="let entry of myObject | objectParser">
                   <dl class="dl-horizontal" *ngIf="entry.value !='' && entry.value != null">
                     <dt>{{entry.key}} <label *ngIf="isArray(entry.value)" class="label label-primary" style="display: inline-table; margin:0px">{{ entry.value.length}}</label></dt>
-                    <dd *ngIf="!isArray(entry.value)">
+                    <dd *ngIf="!isArray(entry.value) && !isObject(entry.value)">
                       {{entry.value}}
                     </dd>
+                    <ng-container *ngIf="isObject(entry.value) && !isArray(entry.value)">
+                      <ng-container *ngIf="entry.value.multi">
+                      <dd *ngFor="let multi of entry.value.multi | objectParser">
+                      {{multi.key}} - {{multi.value}}
+                      </dd>
+                       </ng-container>
+                    </ng-container>
                     <div *ngIf="isArray(entry.value)" style="margin-bottom:10px">
                       <div *ngFor="let val of entry.value; let i = index">
                         <div *ngIf="isObject(val)">
                           <dd *ngIf="val.Report != null" [ngClass]="reportMetricStatus[val.Report]?.class">{{val?.ID}} <i [ngClass]="reportMetricStatus[val.Report]?.icon"></i>
-                          <dd *ngIf="val.Report == null">{{val.TagID}} - {{val.Alias}}</dd>
+                          <dd *ngIf="val.Report == null && !val.Label">{{val.TagID}} - {{val.Alias}}</dd>
+                          <dd *ngIf="!val.Report && val.Label"> {{val.Label}} - {{val.GetMode}} </dd>
                         </div>
                         <div *ngIf="!isObject(val)">
-                          <dd> {{val}}</dd>
+                          <dd> {{val | json}}</dd>
                         </div>
                       </div>
                     </div>
@@ -56,22 +64,22 @@ import { ModalDirective } from 'ngx-bootstrap';
 
 export class GenericModal {
   @ViewChild('childModal') public childModal: ModalDirective;
-  @Input() titleName : any;
+  @Input() titleName: any;
   @Input() customMessage: string;
   @Input() showValidation: boolean;
   @Input() textValidation: string;
   @Input() customMessageClass: string;
   @Input() controlSize: boolean;
 
-  @Output() public validationClicked:EventEmitter<any> = new EventEmitter();
+  @Output() public validationClicked: EventEmitter<any> = new EventEmitter();
 
-  public validationClick(myId: string):void {
+  public validationClick(myId: string): void {
     this.validationClicked.emit(myId);
   }
 
   constructor() { }
   myObject: any = null;
-  empty : any = false;
+  empty: any = false;
 
   public reportMetricStatus: Array<Object> = [
     { value: 0, name: 'Never Report', icon: 'glyphicon glyphicon-remove-circle', class: 'text-danger' },
@@ -79,19 +87,19 @@ export class GenericModal {
     { value: 2, name: 'Report if not zero', icon: 'glyphicon glyphicon-ban-circle', class: 'text-warning' }
   ];
 
-  parseObject( myObject : any){
+  parseObject(myObject: any) {
     this.myObject = myObject;
     this.empty = (Object.keys(myObject).length > 1);
     this.childModal.show();
   }
 
-  isArray (myObject) {
+  isArray(myObject) {
     return myObject instanceof Array;
   }
 
-  isObject (myObject) {
-  return typeof myObject === 'object'
-}
+  isObject(myObject) {
+    return typeof myObject === 'object'
+  }
 
 
   hide() {

--- a/src/common/multiselect-dropdown.ts
+++ b/src/common/multiselect-dropdown.ts
@@ -22,6 +22,7 @@ const MULTISELECT_VALUE_ACCESSOR: any = {
 export interface IMultiSelectOption {
     id: any;
     name: string;
+    badge?: string;
 }
 
 export interface IMultiSelectSettings {
@@ -60,7 +61,11 @@ export class MultiSelectSearchFilter {
     selector: 'ss-multiselect-dropdown',
     providers: [MULTISELECT_VALUE_ACCESSOR],
     styles: [`
-		a { outline: none !important; }
+        a { outline: none !important; }
+        .badge-multi {
+            background-color: #92c0e8;
+            float: right;
+        }
 	`],
     template: `
         <div class="btn-group">
@@ -93,7 +98,8 @@ export class MultiSelectSearchFilter {
                     <a href="javascript:;" role="menuitem" tabindex="-1" (click)="setSelected($event, option)">
                         <input *ngIf="settings.checkedStyle == 'checkboxes'" type="checkbox" [checked]="isSelected(option)" />
                         <span *ngIf="settings.checkedStyle == 'glyphicon'" style="width: 16px;" [ngClass]="isSelected(option) ? ['glyphicon glyphicon-ok' , 'text-success'] : 'glyphicon'"></span>
-                        {{ option.name }}
+                        <span *ngIf="option.badge" style="padding-left: 10px"> | </span> 
+                        {{ option.name }} <span *ngIf="option.badge" class="badge badge-multi"> {{option.badge}} </span>
                     </a>
                 </li>
             </ul>

--- a/src/common/ng-table/components/table/ng-table.component.ts
+++ b/src/common/ng-table/components/table/ng-table.component.ts
@@ -12,6 +12,17 @@ import { ElapsedSecondsPipe } from '../../../elapsedseconds.pipe';
       display: inline !important;
       padding-left: 5px;
     }
+    :host >>> .padd {
+      padding-right: 20px;
+    }
+    :host >>> .marg td {
+      padding-top: 5px;
+      white-space: nowrap;
+    }
+    :host >>> .badge-multi {
+      background-color: #92c0e8;
+      margin-right: 10px;
+  }
 `]
 })
 export class NgTableComponent {

--- a/src/common/ng-table/components/table/ng-table.html
+++ b/src/common/ng-table/components/table/ng-table.html
@@ -61,7 +61,7 @@
                 <input *ngIf="column.filtering " placeholder="{{column.filtering.placeholder}} " [ngTableFiltering]="column.filtering " class="form-control " style="width: auto; " (tableChanged)="onChangeTable(config) " />
             </td>
         </tr>
-        <tr *ngFor="let row of rows ">
+        <tr *ngFor="let row of rows; index as i ">
             <td *ngIf="editMode==true ">
                 <i [ngClass]="checkItems(row.ID) ? [ 'glyphicon glyphicon-unchecked text-danger'] : [ 'glyphicon glyphicon-check text-success'] " (click)="selectItem(row) "></i>
             </td>

--- a/src/common/test-connection-modal.ts
+++ b/src/common/test-connection-modal.ts
@@ -278,7 +278,15 @@ export class TestConnectionModal implements OnInit  {
       data => {
           this.selectors[index].Array = [];
           for (let entry of data) {
-            this.selectors[index].Array.push({ 'id': entry.ID, 'name': entry.ID, 'OID': entry.IndexOID});
+            if (entry.MultiIndexCfg != null) {
+              for (let mi of entry.MultiIndexCfg) {
+                if (mi.GetMode === type) {
+                  this.selectors[index].Array.push({ 'id': entry.ID+".."+mi.Label, 'name': entry.ID+".."+mi.Label, 'OID': mi.IndexOID});
+                }
+              }
+            } else {
+              this.selectors[index].Array.push({ 'id': entry.ID, 'name': entry.ID, 'OID': entry.IndexOID});
+            }
           }
       },
       err => console.error(err),

--- a/src/common/validation.service.ts
+++ b/src/common/validation.service.ts
@@ -2,6 +2,7 @@ export class ValidationService {
     static getValidatorErrorMessage(validatorName: string, validatorValue?: any) {
         let config = {
             'required': 'Required',
+            'notEmpty': 'Required',
             'invalidCreditCard': 'Is invalid credit card number',
             'invalidEmailAddress': 'Invalid email address',
             'invalidPassword': 'Invalid password. Password must be at least 6 characters long, and contain a number.',
@@ -182,6 +183,14 @@ export class ValidationService {
                 return { 'invalidFQDNHost': true };
             }
         }
+    }
+
+    static notEmpty(control) {
+        if (control.value) {
+            console.log("VALUEEE", control.value)
+        }
+        return {'notEmpty': true}
+        
     }
 
 

--- a/src/css/component-styles.css
+++ b/src/css/component-styles.css
@@ -33,12 +33,7 @@ label {
   padding-left: 10px;
 }
 
-input, button {
- // display: block;
-}
-
 select,input {
- //  float: right;
     display: inline;
     width: 320px;
     height: 27px;
@@ -63,7 +58,7 @@ select,input {
   font-weight: 300;
 }*/
 
-input:focus.ng-invalid,select:focus.ng-invalid, textarea:focus.ng-invalid {
+input:focus.ng-invalid,select:focus.ng-invalid, textarea:focus.ng-invalid:not(accordion) {
   box-shadow: 0 0 5px #a94442;
   border: 1px solid #a94442;
   border-left: 5px solid #a94442
@@ -94,7 +89,7 @@ input:focus.ng-valid, select:focus.ng-valid{
   border-left:5px solid #337ab7 !important;
 }
 
-.ng-invalid:not(form)  {
+.ng-invalid:not(form):not(accordion):not(.not-invalid)  {
   border-left: 5px solid #a94442; /* red */
 }
 
@@ -104,7 +99,7 @@ input:focus.ng-valid, select:focus.ng-valid{
   max-height: 70vh;
 }
 
-.ng-valid:not(pagination).ng-valid:not(form) {
+.ng-valid:not(pagination).ng-valid:not(.not-invalid).ng-valid:not(form) {
   border-left: 5px solid #42A948; /* green */
 }
 
@@ -119,4 +114,24 @@ input:focus.ng-valid, select:focus.ng-valid{
 control-messages {
   color: #E82C0C;
   margin: 6px 0;
+}
+
+
+.anim {
+  /* above styles */
+  animation: animation-name .3s ease-out forwards;
+}
+
+@keyframes animation-name {
+ 0% {
+   
+   opacity: 0;
+ }
+ 100% {
+   opacity: 1;
+ }
+}
+
+:host >>> .panel-heading.card-header{
+  background-color: #ffffff !important;
 }

--- a/src/influxmeas/influxmeascfg.data.ts
+++ b/src/influxmeas/influxmeascfg.data.ts
@@ -5,12 +5,12 @@ export const InfluxMeasCfgComponentConfig: any =
       { title: 'ID', name: 'ID' },
       { title: 'Name', name: 'Name' },
       { title: 'GetMode', name: 'GetMode' },
-      { title: 'Index OID', name: 'IndexOID' },
-      { title: 'Tag OID', name: 'TagOID' },
-      { title: 'Index Tag', name: 'IndexTag' },
-      { title: 'Index Tag Format', name: 'IndexTagFormat' },
-      { title: 'Index as Value', name: 'IndexAsValue' },
-      { title: 'Metric Fields', name: 'Fields'}
+      { title: 'Index OID', name: 'IndexOID', transform: 'multi' },
+      { title: 'Tag OID', name: 'TagOID', transform: 'multi' },
+      { title: 'Index Tag', name: 'IndexTag', transform: 'multi' },
+      { title: 'Index Tag Format', name: 'IndexTagFormat', transform: 'multi' },
+      { title: 'Index as Value', name: 'IndexAsValue', transform: 'multi' },
+      { title: 'Metric Fields', name: 'Fields', transform: "metrics"}
     ],
     'slug' : 'measurementcfg'
   }; 

--- a/src/influxmeas/influxmeascfg.service.ts
+++ b/src/influxmeas/influxmeascfg.service.ts
@@ -40,6 +40,35 @@ export class InfluxMeasService {
             if (influxmeas) {
                 _.forEach(influxmeas,function(value,key){
                     console.log("FOREACH LOOP",value,key);
+                    if (value.GetMode == "indexed_mit") {
+                        if (value.MultiTagOID.length > 0 ) {
+                        value.TagOID = {multi: {}}
+                         for (let t in value.MultiTagOID) {
+                             value.TagOID.multi[t] = value.MultiTagOID[t].TagOID
+                         }
+                        }
+                    }
+                    if (value.GetMode == "indexed_multiple") {
+                        value.IndexOID = {multi: {}}
+                        value.TagOID = {multi: {}}
+                        value.IndexTag = {multi: {}}
+                        value.IndexTagFormat = {multi: {}}
+                        value.IndexAsValue = { multi: {}}
+                        for (let mm of value.MultiIndexCfg) {
+                            value.IndexOID.multi[mm.Label] = mm.IndexOID
+                            if (mm.GetMode == "indexed_mit") {
+                                console.log(mm.GetMode, mm.Label)
+                                for (let t in mm.MultiTagOID) {
+                                    value.TagOID.multi[mm.Label+"["+t+"]"] = mm.MultiTagOID[t].TagOID    
+                                } 
+                            } else {
+                                value.TagOID.multi[mm.Label] = mm.TagOID
+                            }
+                            value.IndexTag.multi[mm.Label] = mm.IndexTag
+                            value.IndexTagFormat.multi[mm.Label] = mm.IndexTagFormat
+                            value.IndexAsValue.multi[mm.Label] = mm.IndexAsValue ? mm.IndexAsValue : false
+                        }
+                    }
                     if(filter_s && filter_s.length > 0 ) {
                         console.log("maching: "+value.ID+ "filter: "+filter_s);
                         var re = new RegExp(filter_s, 'gi');

--- a/src/influxmeas/influxmeaseditor.html
+++ b/src/influxmeas/influxmeaseditor.html
@@ -7,7 +7,7 @@
     </test-modal>
     <export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
     <table-list #listTableComponent [typeComponent]="defaultConfig['slug']" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting" [tableRole]="tableRole"
-    [sanitizeCell]="cellParser" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
+    [sanitizeCell]="tableCellParser" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
   </ng-template>
 
   <ng-template ngSwitchDefault>
@@ -59,6 +59,8 @@
             <option value="value">(snmp scalar) Direct Value</option>
             <option value="indexed">(snmp Table) Indexed with direct TAG</option>
             <option value="indexed_it">(snmp Table) Indexed with indirect TAG </option>
+            <option value="indexed_mit">(snmp Table) Indexed with multiple indirect TAG </option>
+            <option value="indexed_multiple">(snmp Table) Multiple indexes </option>
           </select>
           <control-messages [control]="influxmeasForm.controls.GetMode"></control-messages>
         </div>
@@ -73,6 +75,67 @@
           </div>
         </div>
 
+        <ng-container *ngIf="influxmeasForm.controls.MultiTagOID">
+          <label class="control-label col-sm-2">Multi Tag OID</label>
+          <div class="col-sm-10">
+          </div>
+          <div class="col-sm-2"></div>
+          <div class="col-sm-10" style="margin-bottom: 20px">
+            <p style="display: inline-block;">
+              <button type="button" class="btn btn-primary"  (click)="addMultiTagOID()">
+                <i class="glyphicon glyphicon-plus">
+                </i>
+              </button>
+            </p>   
+
+        <div formArrayName="MultiTagOID" class="not-invalid" >
+          <control-messages [control]="influxmeasForm.controls.MultiTagOID"></control-messages>
+
+          <accordion>
+            <div *ngFor="let mult_index of MultiTagOID.controls; let i=index;  let fi = first;  let li = last;">
+              <div class="anim">
+                <accordion-group class="col-sm-10" style="padding: 0px;" [formGroupName]="i">
+                  <button class="btn btn-link btn-block clearfix" accordion-heading type="button">
+                    <div class="pull-left float-left">
+                      <p class="text-left text-dark">TagOID {{i}} | {{influxmeasForm.value.MultiTagOID[i].TagOID}}
+                    </div>
+                    <span class="badge badge-secondary float-right pull-right"></span>
+                  </button>
+                  <div class="form-group" *ngIf="mult_index.controls.TagOID">
+                    <label class="control-label col-sm-2" for="Label">Index TagOID</label>
+                    <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
+                    <div class="col-sm-9">
+                      <input formControlName="TagOID" id="TagOID" [ngModel]="influxmeasForm.value.MultiTagOID[i].TagOID"/>
+                      <control-messages [control]="mult_index.controls.TagOID"></control-messages>
+                    </div>
+                  </div>
+                  <div class="form-group" *ngIf="mult_index.controls.IndexFormat">
+                    <label class="control-label col-sm-2" for="IndexFormat">IndexFormat</label>
+                    <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Format index to change the check condition with $IDX1, $VAL1 (default $VAL1"></i>
+                    <div class="col-sm-9">
+                      <input formControlName="IndexFormat" id="IndexFormat" [ngModel]="influxmeasForm.value.MultiTagOID[i].IndexFormat"/>
+                      <control-messages [control]="mult_index.controls.IndexFormat"></control-messages>
+                    </div>
+                  </div>
+              </accordion-group>
+              <div class="col-sm-2">
+                <button type="button" class="btn btn-primary btn-xs">
+                  <i class="glyphicon glyphicon-remove" (click)="removeTagOID(i)" ></i>
+                </button>
+                <button type="button" class="btn btn-primary btn-xs" [disabled] = "fi">
+                <i class="glyphicon glyphicon-arrow-up" (click)="promoteTagOID(i)"></i>
+              </button>
+              <button type="button" class="btn btn-primary btn-xs" [disabled] = "li">
+                <i class="glyphicon glyphicon-arrow-down"  (click)="demoteTagOID(i)"></i>
+              </button>
+              </div>
+              </div>
+              </div>
+            </accordion>
+        </div>
+      </div>
+        <br>
+        </ng-container>
           <div class="form-group" *ngIf="influxmeasForm.controls.TagOID">
             <label class="control-label col-sm-2" for="TagOID">TagOID</label>
             <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
@@ -112,7 +175,204 @@
           </div>
         </div>
 
-      <div class="form-group">
+       <ng-container *ngIf="influxmeasForm.controls.MultiIndexCfg">
+        <label class="control-label col-sm-2">Multi Index Measurements</label>
+        <div class="col-sm-10">
+         
+        </div>
+        <div class="col-sm-2"></div>
+        <div class="col-sm-10" style="margin-bottom: 20px">
+          <p style="display: inline-block;">
+            <button type="button" class="btn btn-primary"  (click)="addMultiIndex(sel.value)">
+              <i class="glyphicon glyphicon-plus">
+              </i>
+            </button>
+          </p>   
+
+          <select #sel style="display: inline;">
+            <option value="indexed">(snmp Table) Indexed with direct TAG</option>
+            <option value="indexed_it">(snmp Table) Indexed with indirect TAG </option>
+            <option value="indexed_mit">(snmp Table) Indexed with multiple indirect TAG </option>
+          </select>
+
+        <div formArrayName="MultiIndexCfg" class="not-invalid" >
+          <accordion>
+
+          <div *ngFor="let mult_index of MultiIndexCfg.controls; let i=index;  let fi = first;  let li = last;">
+          <div class="anim">
+            <accordion-group class="col-sm-10" style="padding: 0px;" [formGroupName]="i">
+              <button class="btn btn-link btn-block clearfix" accordion-heading type="button">
+                <div class="pull-left float-left">
+                  <p class="text-left text-dark">Index {{i}} | {{influxmeasForm.value.MultiIndexCfg[i].Label}}<span *ngIf="influxmeasForm.value.MultiIndexCfg[i].Dependency !== ''"> | {{influxmeasForm.value.MultiIndexCfg[i].Dependency}} </span></p>
+                  <p class="text-left text-muted">{{influxmeasForm.value.MultiIndexCfg[i].Description}}</p>
+                </div>
+                <span class="badge badge-secondary float-right pull-right">
+                  <span *ngIf="influxmeasForm.value.MultiIndexCfg[i].GetMode == 'indexed'">indexed - (snmp Table) Indexed with direct TAG</span>
+                  <span *ngIf="influxmeasForm.value.MultiIndexCfg[i].GetMode == 'indexed_it'">indexed_it - (snmp Table) Indexed with indirect TAG</span>
+                  <span *ngIf="influxmeasForm.value.MultiIndexCfg[i].GetMode == 'indexed_mit'">indexed_mit - (snmp Table) Indexed with multiple indirect TAG</span>
+                  </span>
+
+              </button>
+
+            <!--div-->
+              <div class="form-group" *ngIf="mult_index.controls.Label">
+                <label class="control-label col-sm-2" for="Label">Index Label</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of the index"></i>
+                <div class="col-sm-9">
+                  <input formControlName="Label" id="Label" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].Label"/>
+                  <control-messages [control]="mult_index.controls.Label"></control-messages>
+                </div>
+              </div>
+              <div class="form-group" *ngIf="mult_index.controls.Description">
+                <label class="control-label col-sm-2" for="Description">Index Description</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the index"></i>
+                <div class="col-sm-9">
+                  <input formControlName="Description" id="Label" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].Description"/>
+                  <control-messages [control]="mult_index.controls.Description"></control-messages>
+                </div>
+              </div>
+              <hr>
+              <div class="form-group" *ngIf="mult_index.controls.IndexOID">
+                <label class="control-label col-sm-2" for="IndexOID">Index Base OID</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The index OID to get the all real OID's to query data"></i>
+                <div class="col-sm-9">
+                  <input formControlName="IndexOID" id="IndexOID" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].IndexOID"/>
+                  <control-messages [control]="mult_index.controls.IndexOID"></control-messages>
+                </div>
+              </div>
+      
+                <div class="form-group" *ngIf="mult_index.controls.TagOID">
+                  <label class="control-label col-sm-2" for="TagOID">Index TagOID</label>
+                  <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
+                  <div class="col-sm-9">
+                    <input formControlName="TagOID" id="TagOID" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].TagOID"/>
+                    <control-messages [control]="mult_index.controls.TagOID"></control-messages>
+                  </div>
+                </div>
+      
+              <div class="form-group" *ngIf="mult_index.controls.IndexTag">
+                <label class="control-label col-sm-2" for="IndexTag">Index Tag</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag name that will be sent after data gathered"></i>
+                <div class="col-sm-9">
+                  <input formControlName="IndexTag" id="IndexTag" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].IndexTag"/>
+                  <control-messages [control]="mult_index.controls.IndexTag"></control-messages>
+                </div>
+              </div>
+      
+              <div class="form-group" *ngIf="mult_index.controls.IndexTagFormat">
+                <label class="control-label col-sm-2" for="IndexTag">Index Tag Format</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Tag value will be sent parametrized with $IDX1 , $VAL1 (default $VAL1 on direct indexed) and $IDX2, $VAL2 (default $VAL2 on indirect indexed) "></i>
+                <div class="col-sm-9">
+                  <input formControlName="IndexTagFormat" id="IndexTagFormat" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].IndexTagFormat"/>
+                  <control-messages [control]="mult_index.controls.IndexTagFormat"></control-messages>
+                </div>
+              </div>
+
+              <ng-container *ngIf="mult_index.controls.MultiTagOID">
+                <label class="control-label col-sm-2">Multi Tag OID</label>
+                <div class="col-sm-10">
+                </div>
+                <div class="col-sm-2"></div>
+                <div class="col-sm-10" style="margin-bottom: 20px">
+                  <p style="display: inline-block;">
+                    <button type="button" class="btn btn-primary"  (click)="addMIMultiTagOID(i)">
+                      <i class="glyphicon glyphicon-plus">
+                      </i>
+                    </button>
+                  </p>   
+      
+                  <!--- MULTITAGOID -->
+              <div formArrayName="MultiTagOID" class="not-invalid" >     
+                <accordion>
+                  <div *ngFor="let mult_tag of mult_index.controls.MultiTagOID.controls; let j=index;  let jfi = first;  let jli = last;">
+                    <div class="anim">
+                      <accordion-group class="col-sm-10" style="padding: 0px;" [formGroupName]="j">
+                        <button class="btn btn-link btn-block clearfix" accordion-heading type="button">
+                          <div class="pull-left float-left">
+                            <p class="text-left text-dark">TagOID {{j}} | {{influxmeasForm.value.MultiIndexCfg[i].MultiTagOID[j].TagOID}}
+                          </div>
+                          <span class="badge badge-secondary float-right pull-right"></span>
+                        </button>
+                        <div class="form-group" *ngIf="mult_tag.controls.TagOID">
+                          <label class="control-label col-sm-2" for="Label">Index TagOID</label>
+                          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Tag OID will allow us to get real Tag Name not provided in the IndexOID"></i>
+                          <div class="col-sm-9">
+                            <input formControlName="TagOID" id="TagOID" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].MultiTagOID[j].TagOID"/>
+                            <control-messages [control]="mult_tag.controls.TagOID"></control-messages>
+                          </div>
+                        </div>
+                        <div class="form-group" *ngIf="mult_tag.controls.IndexFormat">
+                          <label class="control-label col-sm-2" for="IndexFormat">IndexFormat</label>
+                          <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Format index to change the check condition with $IDX1, $VAL1 (default $VAL1"></i>
+                          <div class="col-sm-9">
+                            <input formControlName="IndexFormat" id="IndexFormat" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].MultiTagOID[j].IndexFormat"/>
+                            <control-messages [control]="mult_tag.controls.IndexFormat"></control-messages>
+                          </div>
+                        </div>
+                    </accordion-group>
+                    <div class="col-sm-2">
+                      <button type="button" class="btn btn-primary btn-xs">
+                        <i class="glyphicon glyphicon-remove" (click)="removeMITagOID(i,j)"></i>
+                      </button>
+                      <button type="button" class="btn btn-primary btn-xs" [disabled] = "jfi">
+                      <i class="glyphicon glyphicon-arrow-up" (click)="promoteMITagOID(i,j)"></i>
+                    </button>
+                    <button type="button" class="btn btn-primary btn-xs" [disabled] = "jli">
+                      <i class="glyphicon glyphicon-arrow-down"  (click)="demoteMITagOID(i,j)"></i>
+                    </button>
+                    </div>
+                    </div>
+                    </div>
+                  </accordion>
+              </div>
+            </div>
+              <br>
+              </ng-container>
+              <hr>
+              <div class="form-group" *ngIf="mult_index.controls.Dependency">
+                <label class="control-label col-sm-2" for="Dependency">Index Dependency</label>
+                <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The dependency syntax to heridate tags from other indexes. The syntax follows: IM{N};DOT[XXX-YYY];SKIP|FILL(XXX)
+                IM{N} references the index N. The DOT[XXX-YYY] references the OID range to check its dependency. The SKIP|FILL(XXX) references the fill strategy in case that heridate doesn't match the current index. SKIP will remove indexes, FILL(XXX) will fill the 
+                value with desired one"></i>
+                <div class="col-sm-9">
+                  <input formControlName="Dependency" id="Dependency" [ngModel]="influxmeasForm.value.MultiIndexCfg[i].Dependency"/>
+                  <control-messages [control]="mult_index.controls.Dependency"></control-messages>
+                </div>
+              </div>   
+
+            <!--/div-->
+          </accordion-group>
+          <div class="col-sm-2">
+            <button type="button" class="btn btn-primary btn-xs">
+              <i class="glyphicon glyphicon-remove" (click)="removeMeas(i)" ></i>
+            </button>
+            <button type="button" class="btn btn-primary btn-xs" [disabled] = "fi">
+            <i class="glyphicon glyphicon-arrow-up" (click)="promoteMeas(i)"></i>
+          </button>
+          <button type="button" class="btn btn-primary btn-xs" [disabled] = "li">
+            <i class="glyphicon glyphicon-arrow-down"  (click)="demoteMeas(i)"></i>
+          </button>
+          </div>
+          </div>
+          </div>
+        </accordion>
+
+          </div>
+
+     </div>
+     <div class="form-group" *ngIf="influxmeasForm.controls.MultiIndexResult">
+      <label class="control-label col-sm-2" for="MultiIndexResult">Multi Index Result</label>
+      <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Build the new index from indexes. The syntax follows as: .1.IDX{M}, on IDX{M} is an index. If multiple indexes are used, the result will be the scalar product between all pairs of [index:value]"></i>
+      <div class="col-sm-9">
+        <input formControlName="MultiIndexResult" id="MultiIndexResult" [ngModel]="influxmeasForm.value.MultiIndexResult"/>
+        <control-messages [control]="influxmeasForm.controls.MultiIndexResult"></control-messages>
+      </div>
+    </div>
+     <br>
+
+      </ng-container>
+
+      <div class="form-group" >
         <label class="control-label col-sm-2" for="Fields">Fields</label>
         <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of metrics to associate with the measurement {{influxmeasForm.value.ID}}"></i>
         <div class="col-sm-9">
@@ -148,13 +408,15 @@
         </div>
       </div>
     </div>
+
+
       <div class="well well-sm">
         <span class="editsection">
           Extra Settings
         </span>
         <div class="form-group" style="margin-top: 25px">
         <label class="control-label col-sm-2" for="Description">Description</label>
-        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement Group"></i>
+        <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Measurement"></i>
         <div class="col-sm-9">
           <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="influxmeasForm.value.Description"> </textarea>
           <control-messages [control]="influxmeasForm.controls.Description"></control-messages>

--- a/src/measfilter/measfiltercfg.component.ts
+++ b/src/measfilter/measfiltercfg.component.ts
@@ -346,6 +346,11 @@ export class MeasFilterCfgComponent {
         for (let entry of data) {
           console.log(entry)
           this.selectmeas.push({ 'id': entry.ID, 'name': entry.ID });
+          if (entry.GetMode == "indexed_multiple") {
+            for (let mi of entry.MultiIndexCfg) {
+              this.selectmeas.push({'id': entry.ID+'..'+mi.Label, 'name': mi.Label, 'badge': "indexed multiple" })
+            }
+          }
         }
 
        },

--- a/src/measfilter/measfiltereditor.html
+++ b/src/measfilter/measfiltereditor.html
@@ -4,8 +4,7 @@
 		<test-modal #viewModal titleName='Measurement Filters'></test-modal>
 		<test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this Measurement Filter will affect the following components','Deleting this Measurement Filter will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
 						[showValidation]="true" [textValidation]="'Delete'" [controlSize]="true" (validationClicked)="deleteMeasFilter($event)">
-		</test-modal>
-		<export-file-modal #exportFileModal [showValidation]="true" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
+		</test-modal>		
     <export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
     <table-list #listTableComponent [typeComponent]="defaultConfig['slug']" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting" [tableRole]="tableRole"
     [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>

--- a/src/runtime/runtime.component.ts
+++ b/src/runtime/runtime.component.ts
@@ -155,12 +155,13 @@ export class RuntimeComponent implements OnDestroy {
     filteredData.forEach((item: any) => {
       let flag = false;
       this.columns.forEach((column: any) => {
+        console.log(item)
         if (item[column.name] === null) {
           item[column.name] = '--'
         }
         if (item[column.name].toString().match(this.config.filtering.filterString)) {
           flag = true;
-        }
+        }  
       });
       if (flag) {
         tempArray.push(item);
@@ -285,7 +286,7 @@ export class RuntimeComponent implements OnDestroy {
             //Save it as array of arrays on finalColumns
             if (Object.keys(measKey['MetricTable']['Header']).length !== 0) {
               this.tmpcolumns = [];
-              if (measKey['TagName'] !== "") this.tmpcolumns.push({ title: measKey['TagName'], name: 'Index' });
+              if (measKey['TagName'] !== null) this.tmpcolumns.push({ title: measKey['TagName'], name: 'Index' });
               for (let fieldName in measKey['MetricTable']['Header']) {
                 let fdata = measKey['MetricTable']['Header'][fieldName]
                 let mtype =  measKey['MetricTable']['Header'][fieldName]["Type"]

--- a/src/runtime/runtimeview.html
+++ b/src/runtime/runtimeview.html
@@ -246,8 +246,12 @@
                                             <dd *ngFor="let metrics of finalColumns[i]"><span *ngIf="metrics.title !== 'Index'">{{metrics.title}}</span></dd>
                                         </dl>
                                     </ng-template>
-                                    <span *ngIf="measurement.TagName.length !== 0 " [ngClass]="i === measActive ? 'badge' : 'label label-default'">{{finalData[i].length}} index</span>
-                                    <span *ngIf="measurement.TagName.length == 0 " [ngClass]="i === measActive ? 'badge' : 'label label-default'"> value </span>
+                                    <ng-container *ngIf="measurement.TagName != null">
+                                        <span *ngIf="measurement.TagName.length !== 0 " [ngClass]="i === measActive ? 'badge' : 'label label-default'">{{finalData[i].length}} index</span>
+                                    </ng-container>
+                                    <ng-container *ngIf="measurement.TagName == null">
+                                        <span [ngClass]="i === measActive ? 'badge' : 'label label-default'"> value </span>
+                                    </ng-container>
                                 </button>
                             </span>
                         </div>
@@ -264,7 +268,13 @@
                             </select>
                         </div>
                         <div class="col-md-3 text-right">
-                            <span class="label label-danger" [tooltip]="filterInfo" style="margin-left: 10px" *ngIf="runtime_dev['Measurements'][measActive].Filter"> Filter applied: {{runtime_dev['Measurements'][measActive].FilterCfg.ID}}</span>
+                            <div class="col-md-12 text-left" style="margin-bottom: 5px">
+                            <span class="label label-info" [tooltip]="multiMeasInfo">Base: {{runtime_dev['Measurements'][measActive].ID}}</span>
+                        </div>
+                        <div class="col-md-12 text-left" style="margin-bottom: 5px">
+
+                            <span class="label label-danger" [tooltip]="filterInfo" style="margin-left: 10px" *ngIf="runtime_dev['Measurements'][measActive].Filter"> - Filter applied: {{runtime_dev['Measurements'][measActive].FilterCfg.ID}}</span>
+
                             <ng-template #filterInfo>
                                 <div *ngFor="let run of runtime_dev['Measurements'][measActive].Filter | objectParser" style="text-align:left !important">
                                     <span class="text-left" style="padding-left: 10px"><b>{{run.key}}</b></span>
@@ -272,6 +282,29 @@
                                 </div>
                             </ng-template>
                         </div>
+
+                        <ng-container class="col-md-3 text-right" *ngIf="runtime_dev['Measurements'][measActive].MultiIndexMeas">
+
+                        <ng-container *ngFor="let multi of runtime_dev['Measurements'][measActive].MultiIndexMeas">
+                            <div  class="col-md-12 text-left" style="margin-bottom: 7px" >
+                                <span>-</span>
+                                <span class="label label-warning" style="margin-left: 10px"> MultiIndexed: {{multi.ID}}</span> 
+                                </div>
+                                <div  class="col-md-12 text-left" style="margin-bottom: 5px" *ngIf="multi.FilterCfg" >
+                                    <span>-</span>
+                                <span class="label label-danger" [tooltip]="filterInfo" style="margin-left: 20px"  *ngIf="multi.Filter">Filter applied: {{multi.FilterCfg.ID}}</span>
+                                <ng-template #filterInfo>
+                                    <div *ngFor="let run of multi.Filter | objectParser" style="text-align:left !important">
+                                        <span class="text-left" style="padding-left: 10px"><b>{{run.key}}</b></span>
+                                        <span class="text-right">{{run.value ? run.value : '--'}}</span>
+                                    </div>
+                                </ng-template>
+                            </div>
+                        </ng-container>
+                            </ng-container>
+                    </div>
+
+
                         <div style="overflow-x: scroll" class="col-md-12">
                             <ng-table [config]="config" [sanitizeCell]="tableCellParser" [tableRole]="tableRole" (tableChanged)="onChangeTable(config)" (viewedItem)="viewItem($event)" (editedItem)="editMeasGroup($event)" (removedItem)="removeItem($event)" [showCustom]="false" [rows]="rows" [columns]="columns" [checkRows]="true">
                             </ng-table>


### PR DESCRIPTION
SNMPCollector only allowed basic measurements: direct and indirect
index. It covered almost all the cases, but some complicated MIBs like
Cisco QoS were not possible to be retrieved

This PR adds new measurement types based on GetMode property to allow to
retrieve metrics from complicated MIBs like QoS

- Indexed with multi indirect TAG:
Allow to define multiple TagOIDs with custom index comparison in order
to irerate over different SNMP tables

- Multi Index:
Alows to define multiple indexes with a dependency system to heridate
tags and build a custom index to be used by measurement metrics