### PR TITLE
Revert octetstring string cast due to revert on core gosnmp lib after 1.28 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-xorm/xorm v0.7.1
 	github.com/google/go-cmp v0.2.0
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
-	github.com/gosnmp/gosnmp v1.28.0
+	github.com/gosnmp/gosnmp v1.28.1-0.20201116205349-412b15e9428b
 	github.com/influxdata/influxdb v1.7.0
 	github.com/influxdata/platform v0.0.0-20181110005748-2f8893f5d5e3 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/goreleaser/goreleaser v0.91.1/go.mod h1:r02//RU0qOOAsbJvZ6Igcu34zJeqR
 github.com/goreleaser/nfpm v0.9.7/go.mod h1:F2yzin6cBAL9gb+mSiReuXdsfTrOQwDMsuSpULof+y4=
 github.com/gosnmp/gosnmp v1.28.0 h1:X3NBU6Ghu5BF0QGEF0zzZhlpTWC8mIqd8a85QnLZ5Jg=
 github.com/gosnmp/gosnmp v1.28.0/go.mod h1:pJUhjlccw5++Tz3HcH/WI9SgnQ/trnmfpFUnOtZMw6s=
+github.com/gosnmp/gosnmp v1.28.1-0.20201116205349-412b15e9428b h1:xRAs+ITmvhYhKlMW6Bo2IHvDAd4A5JUrLUFxEpRgA9Q=
+github.com/gosnmp/gosnmp v1.28.1-0.20201116205349-412b15e9428b/go.mod h1:pJUhjlccw5++Tz3HcH/WI9SgnQ/trnmfpFUnOtZMw6s=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/pkg/data/measurement/measurement.go
+++ b/pkg/data/measurement/measurement.go
@@ -801,7 +801,7 @@ func (m *Measurement) loadIndexedLabels() (map[string]string, error) {
 		name := "ErrorOnGetIdxValue"
 		switch pdu.Type {
 		case gosnmp.OctetString:
-			name = pdu.Value.(string)
+			name = string(pdu.Value.([]byte))
 			m.Debugf("Got the following OctetString index for [%s/%s]", suffix, name)
 		case gosnmp.Counter32, gosnmp.Counter64, gosnmp.Gauge32, gosnmp.Uinteger32:
 			name = strconv.FormatUint(snmp.PduVal2UInt64(pdu), 10)

--- a/pkg/data/snmp/snmp.go
+++ b/pkg/data/snmp/snmp.go
@@ -237,7 +237,7 @@ func GetAlternateSysInfo(id string, client *gosnmp.GoSNMP, l *logrus.Logger, Sys
 		}
 		switch pdu.Type {
 		case gosnmp.OctetString: //  like SysDescr
-			value := fmt.Sprintf("%s = %s", oidname, pdu.Value.(string))
+			value := fmt.Sprintf("%s = %s", oidname, string(pdu.Value.([]byte)))
 			tmpDesc = append(tmpDesc, value)
 		case gosnmp.TimeTicks: // like sysUpTime
 			seconds := uint32(pdu.Value.(uint32)) / 100
@@ -285,7 +285,7 @@ func GetSysInfo(id string, client *gosnmp.GoSNMP, l *logrus.Logger) (SysInfo, er
 		switch idx {
 		case 0: // SysDescr     .1.3.6.1.2.1.1.1.0
 			if pdu.Type == gosnmp.OctetString {
-				info.SysDescr = pdu.Value.(string)
+				info.SysDescr = string(pdu.Value.([]byte))
 			} else {
 				l.Warnf("Error on getting system %s SysDescr return data of type %v", id, pdu.Type)
 			}
@@ -298,19 +298,19 @@ func GetSysInfo(id string, client *gosnmp.GoSNMP, l *logrus.Logger) (SysInfo, er
 			}
 		case 2: // SysContact   .1.3.6.1.2.1.1.4.0
 			if pdu.Type == gosnmp.OctetString {
-				info.SysContact = pdu.Value.(string)
+				info.SysContact = string(pdu.Value.([]byte))
 			} else {
 				l.Warnf("Error on getting system %s SysContact return data of type %v", id, pdu.Type)
 			}
 		case 3: // SysName      .1.3.6.1.2.1.1.5.0
 			if pdu.Type == gosnmp.OctetString {
-				info.SysName = pdu.Value.(string)
+				info.SysName = string(pdu.Value.([]byte))
 			} else {
 				l.Warnf("Error on getting system %s SysName return data of type %v", id, pdu.Type)
 			}
 		case 4: // SysLocation  .1.3.6.1.2.1.1.6.0
 			if pdu.Type == gosnmp.OctetString {
-				info.SysLocation = pdu.Value.(string)
+				info.SysLocation = string(pdu.Value.([]byte))
 			} else {
 				l.Warnf("Error on getting system %s SysLocation return data of type %v", id, pdu.Type)
 			}
@@ -339,7 +339,7 @@ func PduVal2str(pdu gosnmp.SnmpPDU) string {
 	case gosnmp.Uinteger32:
 		return strconv.FormatInt(PduVal2Int64(pdu), 10)
 	case gosnmp.OctetString:
-		return pdu.Value.(string)
+		return string(pdu.Value.([]byte))
 	case gosnmp.ObjectIdentifier:
 		return PduVal2OID(pdu)
 	case gosnmp.IPAddress:
@@ -357,7 +357,7 @@ func PduVal2str(pdu gosnmp.SnmpPDU) string {
 func PduValHexString2Uint(pdu gosnmp.SnmpPDU) (uint64, error) {
 	value := pdu.Value
 	if pdu.Type == gosnmp.OctetString {
-		result, err := strconv.ParseUint(value.(string), 16, 64)
+		result, err := strconv.ParseUint(string(value.([]byte)), 16, 64)
 		return result, err
 	}
 	return 0, fmt.Errorf("The PDU scanned is not and OctetString as expected")

--- a/pkg/mock/snmpserver_test.go
+++ b/pkg/mock/snmpserver_test.go
@@ -108,6 +108,10 @@ func ExampleServerClientWalk() {
 	}
 
 	for _, v := range results {
+		if v.Type == c.OctetString {
+			fmt.Printf("Result for [%s]:  %+v\n", v.Name, string(v.Value.([]byte)))
+			continue
+		}
 		fmt.Printf("Result for [%s]:  %+v\n", v.Name, v.Value)
 	}
 


### PR DESCRIPTION
After the release of gosnmp v.1.28 they reverted the behaviour of octetstring, back to []byte instead of string.
This PR reverts also the changes and fixes gosnmp to the last commit (1.28.1)