### PR TITLE
Feature/add shutdown rt  api option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### fixes
 * Fixed invalid field when using MULTISTRINGPARSER and void capture group. Now the value is ommited and it won't be written on InfluxDB
+* Added  /api/rt/agent/shutdown as fast way to reload config when existing external tools to restart the snmpcollector instance (docker --restart=always) by example
 
 ### breaking changes
 

--- a/pkg/webui/apirt-agent.go
+++ b/pkg/webui/apirt-agent.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ func NewAPIRtAgent(m *macaron.Macaron) error {
 
 	m.Group("/api/rt/agent", func() {
 		m.Get("/reload/", reqSignedIn, AgentReloadConf)
+		m.Get("/shutdown/", reqSignedIn, AgentShutdown)
 		m.Post("/snmpconsole/ping/", reqSignedIn, bind(config.SnmpDeviceCfg{}), PingSNMPDevice)
 		m.Post("/snmpconsole/query/:getmode/:obtype/:data", reqSignedIn, bind(config.SnmpDeviceCfg{}), QuerySNMPDevice)
 		m.Get("/info/version/", RTGetVersion)
@@ -35,6 +37,13 @@ func AgentReloadConf(ctx *Context) {
 		return
 	}
 	ctx.JSON(200, time)
+}
+
+// AgentShutdown xx
+func AgentShutdown(ctx *Context) {
+	log.Info("receiving shutdown")
+	ctx.JSON(200, "Init shutdown....")
+	os.Exit(0)
 }
 
 //PingSNMPDevice xx


### PR DESCRIPTION
In order to accelerate the reconfiguration option ( reloadconf sometimes tooks too much  , at least as many time as the slowest device ) sometimes could be minutes... and this enables the ability to force process shutdown from api, but we need external tools to restart.

Could be a good option if running snmpcollector as docker-image with the ` --restart=always` option. or another kind of supervisor tool like "supervisord".

This option acts as a  fast workaround 