### PR TITLE
Fix invalid field error on MULTISTRINGPARSER with void capture group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# v 0.9.0 ( unreleased )
+# v 0.9.1 ( unreleased )
+### New Features
+
+### fixes
+* Fixed invalid field when using MULTISTRINGPARSER and void capture group. Now the value is ommited and it won't be written on InfluxDB
+
+### breaking changes
+
+# v 0.9.0 ( 2021-01-04 )
 ### New Features
 * Added snmpmetric unit tests
 * Updated to last "gosnmp" v1.28.0 release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "company": "Toni Inc"
   },
   "name": "snmpcollector",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "repository": {
     "type": "git",
     "url": "http://github.com/toni-moreno/snmpcollector.git"

--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -847,6 +847,9 @@ func (s *SnmpMetric) addMultiStringParserValues(tags map[string]string, fields m
 			}
 			tags[i.IName] = i.Value.(string)
 		case "F":
+			if i.Value == nil {
+				continue
+			}
 			fields[i.IName] = i.Value
 		}
 	}


### PR DESCRIPTION
When using MULTISTRINGPARSER metric type, if the used capture group was
empty, it will generate a field with `key=value -->  key=`.

The format is invalid on InfluxDB and data was not being sent

This PR adds a simple check that if the value is null, the field will be
ommited on the output