### PR TITLE
added active_value,connected_value fields and device_active,device_conected tags in order to improve device statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### fixes
 * Fixed invalid field when using MULTISTRINGPARSER and void capture group. Now the value is ommited and it won't be written on InfluxDB
 * Added  /api/rt/agent/shutdown as fast way to reload config when existing external tools to restart the snmpcollector instance (docker --restart=always) by example
+* Improved device stats , Added new tags "device_active", "device_connected" true/false and "active_value/connected_value" as fields with values  0/1, with this new fields/tags we can easily count % devices connected 
 
 ### breaking changes
 

--- a/pkg/agent/selfmon/selfmon.go
+++ b/pkg/agent/selfmon/selfmon.go
@@ -143,21 +143,26 @@ func (sm *SelfMon) addDataPoint(pt *client.Point) {
 }
 
 // AddDeviceMetrics add data from devices
-func (sm *SelfMon) AddDeviceMetrics(deviceid string, fields map[string]interface{}, devtags map[string]string) {
+func (sm *SelfMon) AddDeviceMetrics(deviceid string, fields map[string]interface{}, devtags, statustags map[string]string) {
 	if !sm.IsInitialized() {
 		return
 	}
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
-
+	//Selfmon tags
 	tagMap := make(map[string]string)
 	for k, v := range sm.TagMap {
 		tagMap[k] = v
 	}
+	//device user configured extra tags (only if inherited)
 	if sm.cfg.InheritDeviceTags {
 		for k, v := range devtags {
 			tagMap[k] = v
 		}
+	}
+	//status tags for device
+	for k, v := range statustags {
+		tagMap[k] = v
 	}
 
 	tagMap["device"] = deviceid

--- a/pkg/data/measurement/influxpoint.go
+++ b/pkg/data/measurement/influxpoint.go
@@ -26,8 +26,7 @@ func (m *Measurement) GetInfluxPoint(hostTags map[string]string) (int64, int64, 
 		}
 		Fields := make(map[string]interface{})
 		for _, vMtr := range k.Data {
-			ms, me := vMtr.ImportFieldsAndTags(m.cfg.ID, Fields, Tags)
-			metSent += ms
+			me := vMtr.ImportFieldsAndTags(m.cfg.ID, Fields, Tags)
 			metError += me
 			//check again if metric is valid
 			if vMtr.Valid == true {
@@ -36,6 +35,7 @@ func (m *Measurement) GetInfluxPoint(hostTags map[string]string) (int64, int64, 
 				m.Debugf("SKIPPING TS due to invalid %s metric %s", m.cfg.ID, vMtr.CurTime)
 			}
 		}
+		metSent += int64(len(Fields))
 		m.Debugf("FIELDS:%+v", Fields)
 
 		pt, err := client.NewPoint(m.cfg.Name, Tags, Fields, t)
@@ -75,8 +75,7 @@ func (m *Measurement) GetInfluxPoint(hostTags map[string]string) (int64, int64, 
 			m.Debugf("IDX :%+v", vIdx)
 			Fields := make(map[string]interface{})
 			for _, vMtr := range vIdx.Data {
-				ms, me := vMtr.ImportFieldsAndTags(m.cfg.ID, Fields, Tags)
-				metSent += ms
+				me := vMtr.ImportFieldsAndTags(m.cfg.ID, Fields, Tags)
 				metError += me
 				//check again if metric is valid
 				if vMtr.Valid == true {
@@ -85,6 +84,7 @@ func (m *Measurement) GetInfluxPoint(hostTags map[string]string) (int64, int64, 
 					m.Debugf("SKIPPING TS due to invalid %s metric %s", m.cfg.ID, vMtr.CurTime)
 				}
 			}
+			metSent += int64(len(Fields))
 			//here we can chek Fields names prior to send data
 			m.Debugf("FIELDS:%+v TAGS:%+v", Fields, Tags)
 			pt, err := client.NewPoint(m.cfg.Name, Tags, Fields, t)

--- a/pkg/data/metric/snmpmetric.go
+++ b/pkg/data/metric/snmpmetric.go
@@ -857,40 +857,35 @@ func (s *SnmpMetric) addMultiStringParserValues(tags map[string]string, fields m
 }
 
 // ImportFieldsAndTags Add Fields and tags from the metric and returns number of metric sent and metric errors found
-func (s *SnmpMetric) ImportFieldsAndTags(mid string, fields map[string]interface{}, tags map[string]string) (int64, int64) {
-	var metError int64
-	var metSent int64
+func (s *SnmpMetric) ImportFieldsAndTags(mid string, fields map[string]interface{}, tags map[string]string) int64 {
 	s.log.Debugf("DEBUG METRIC  CONFIG %+v", s.cfg)
 	if s.CookedValue == nil {
 		s.log.Warnf("Warning METRIC ID [%s] from MEASUREMENT[ %s ] with TAGS [%+v] has no valid data => See Metric Runtime [ %+v ]", s.cfg.ID, mid, tags, s)
-		metError++ //not sure if an tag error should be count as metric
-		return metError, metSent
+		return 1
 	}
 	if s.Valid == false {
 		s.log.Warnf("Warning METRIC ID [%s] from MEASUREMENT[ %s ] with TAGS [%+v] has obsolete data => See Metric Runtime [ %+v ]", s.cfg.ID, mid, tags, s)
-		metError++
-		return metError, metSent
+		return 1
 	}
 	if s.Report == NeverReport {
 		s.log.Debugf("REPORT is FALSE in METRIC ID [%s] from MEASUREMENT[ %s ] won't be reported to the output backend", s.cfg.ID, mid)
-		return 0, 0
+		return 0
 	}
 
 	switch s.cfg.DataSrcType {
 	case "MULTISTRINGPARSER":
 		er := s.addMultiStringParserValues(tags, fields)
-		metError += er
+		return er
 	default:
 		if s.cfg.IsTag == true {
 			er := s.addSingleTag(mid, tags)
-			metError += er
+			return er
 		} else {
 			er := s.addSingleField(mid, fields)
-			metError += er
+			return er
 		}
 	}
-
-	return metSent, metError
+	return 0
 }
 
 // MarshalJSON return JSON formatted data


### PR DESCRIPTION
now from grafana we will be able to  query % of devices actives/connected with 1 query queries over device stats.

```
select sum(last_c)*100/sum(last_a) as percent_active from   (select last(connected_value) as last_c, last(active_value) as last_a from selfmon_device_stats where instance='dev-toni' and device_active = 'true' and time > now() - 10m group by device)
time                 percent_active
----                 --------------
1970-01-01T00:00:00Z 100

```
or with absolute numbers.

```
select sum(last_c) as connected , sum(last_a) as active from   (select last(connected_value) as last_c, last(active_value) as last_a from selfmon_device_stats where instance='dev-toni' and device_active = 'true' and time > now() - 10m group by device)
time                 connected active
----                 --------- ------
1970-01-01T00:00:00Z 2         2
```

