### PR TITLE
fix: fix already closed connections on multiindex measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.13.1 ( 2022-11-15 )
+
+### New Features
+
+### Fixes
+
+* fix #524
+
+### breaking changes
+
 # v0.13.0 ( 2022-02-16 )
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "company": "Toni Inc"
   },
   "name": "snmpcollector",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "repository": {
     "type": "git",
     "url": "http://github.com/toni-moreno/snmpcollector.git"

--- a/pkg/data/measurement/measurement.go
+++ b/pkg/data/measurement/measurement.go
@@ -196,7 +196,8 @@ func (m *Measurement) InitMultiIndex() error {
 
 		// create entirely new measurement based on provided CFG
 		mm := New(&mcfg, m.measFilters, m.mFilters, m.Active, m.Log)
-		mm.SetSNMPClient(*m.snmpClient)
+		// use same pointer on same snmpClient as multimeas inherits connection flow from the main measurement
+		mm.snmpClient = m.snmpClient
 		err := mm.Init()
 		if err != nil {
 			return fmt.Errorf("init multi measurement %s..%s", m.ID, v.Label)
@@ -797,6 +798,7 @@ func (m *Measurement) loadIndexedLabels() (map[string]string, error) {
 	}
 	// needed to get data for different indexes
 	m.curIdxPos = m.idxPosInOID
+
 	err := m.snmpClient.Walk(m.cfg.IndexOID, setRawData)
 	if err != nil {
 		m.Log.Errorf("LOADINDEXEDLABELS - SNMP WALK error: %s", err)


### PR DESCRIPTION
On the measurement gatherloop the measurement is marked as non-connected if it becomes unresponsive or the metrica cannot be retrieved for some connectivity reason.

When it happens, the gatherloop tries to reconnect again querying complete sysinfo and resets the snmpclient

This PR tries to fix the logic of the snmpclient inherit from the measurement, as it is using a pointer of a copy instead of the original snmpclient.

In this case, any change on the measurement snmpclient doesn't populates to the multiindex measurement snmpclient, and an already closed connection was being used and the load index is not being done and all the indexes were remain as the last time that they got gethered (wrong if the processed failed at some point)

fix #524